### PR TITLE
ELM v3.1 - Revert back to elm:Mailbox class

### DIFF
--- a/rdf/ap/ams/AMS-constraints.ttl
+++ b/rdf/ap/ams/AMS-constraints.ttl
@@ -816,7 +816,7 @@ ams:ContactPointShape
   ];
   sh:property [
     sh:path elm:emailAddress;
-    sh:class elm:EmailAddress;
+    sh:class elm:Mailbox;
     sh:description "An e-mail address used for contacting the agent."@en;
     sh:name "emailAddress"@en;
     sh:severity sh:Violation;
@@ -1019,14 +1019,14 @@ ams:LegalIdentifierShape
   ];
   .
 
-#------ EmailAddress class and property  shapes --------
-ams:EmailAddressShape
+#------ Mailbox class and property  shapes --------
+ams:MailboxShape
   a sh:NodeShape;
   sh:closed true ;
   sh:ignoredProperties (rdf:type) ;
-  sh:targetClass elm:EmailAddress;
-  rdfs:comment "An e-mail address."@en;
-  rdfs:label "Email Address Shape"@en;
+  sh:targetClass elm:Mailbox;
+  rdfs:comment "A mailbox."@en;
+  rdfs:label "Mailbox Shape"@en;
   .
 
 #------ Media Object class and property  shapes --------

--- a/rdf/ap/ams/documentation/AMS-constraints.html
+++ b/rdf/ap/ams/documentation/AMS-constraints.html
@@ -240,12 +240,12 @@
             <li><a href="#ams:ConceptScheme">Concept  Scheme Shape</a></li>
             <li><a href="#ams:ConceptShape">Concept Shape</a></li>
             <li><a href="#ams:ContactPointShape">Contact Point Shape</a></li>
-            <li><a href="#ams:EmailAddressShape">Email Address Shape</a></li>
             <li><a href="#ams:GeometryShape">Geometry Shape</a></li>
             <li><a href="#ams:GroupShape">Group Shape</a></li>
             <li><a href="#ams:IdentifierShape">Identifier Shape</a></li>
             <li><a href="#ams:LegalIdentifierShape">Legal Identifier Shape</a></li>
             <li><a href="#ams:LocationShape">Location Shape</a></li>
+            <li><a href="#ams:MailboxShape">Mailbox Shape</a></li>
             <li><a href="#ams:MediaObjectShape">Media Object Shape</a></li>
             <li><a href="#ams:NoteShape">Note Shape</a></li>
             <li><a href="#ams:OrganisationShape">Organisation Shape</a></li>
@@ -867,7 +867,7 @@
                 <tr>
                     <td>emailAddress</td>
                     <td><code><a href="http://data.europa.eu/snb/model/elm/emailAddress">elm:emailAddress</a></code></td>
-                    <td><code><a href="#ams:EmailAddressShape">Email Address Shape</a></code><br></td>
+                    <td><code><a href="#ams:MailboxShape">Mailbox Shape</a></code><br></td>
                     <td>
                         <div style="width:30px">0..*</div>
                     </td>
@@ -893,19 +893,6 @@
                 </tr>
                 </tbody>
             </table>
-        </section>
-    </div>
-</div><br><div class="row mt-3">
-    <div class="col">
-        <section id="ams:EmailAddressShape">
-            <div class="sp_section_title_table_wrapper">
-                <h2 class="sp_section_title_table">Email Address Shape</h2>
-            </div>
-            <p><em>An e-mail address.</em></p>
-            <ul class="sp_list_description_properties">
-                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/EmailAddress">elm:EmailAddress</a></li>
-                <li>Closed shape</li>
-            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">
@@ -1330,6 +1317,19 @@
                 </tr>
                 </tbody>
             </table>
+        </section>
+    </div>
+</div><br><div class="row mt-3">
+    <div class="col">
+        <section id="ams:MailboxShape">
+            <div class="sp_section_title_table_wrapper">
+                <h2 class="sp_section_title_table">Mailbox Shape</h2>
+            </div>
+            <p><em>A mailbox.</em></p>
+            <ul class="sp_list_description_properties">
+                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/Mailbox">elm:Mailbox</a></li>
+                <li>Closed shape</li>
+            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">

--- a/rdf/ap/ams/rdf-xml/AMS-constraints.rdf
+++ b/rdf/ap/ams/rdf-xml/AMS-constraints.rdf
@@ -105,7 +105,6 @@
     <sh:targetClass rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/ContactPointShape">
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">address</sh:name>
@@ -113,6 +112,7 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
     </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -123,6 +123,28 @@
       <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
     </sh:property>
     <rdfs:label xml:lang="en">Contact Point Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:and rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:pattern>^(([^:/?#]+):)?(//(([^@\[/?#]*)@)?(\[[[A-Fa-f0-9]\:\.]*[%[\p{L}\p{Nl}\p{Nd}]]*\]|[^\[/?#:]*)(:(\d*(?:\{[^/]+?\})?))?)?([^?#]*)(\?([^#]*))?(#(.*))?</sh:pattern>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:pattern>^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?</sh:pattern>
+        </rdf:Description>
+      </sh:and>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">emailAddress</sh:name>
+      <sh:description xml:lang="en">An e-mail address used for contacting the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/emailAddress"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the contact point.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:node>
         <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/URIRegexRestriction">
@@ -147,33 +169,12 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactForm"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:and rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:pattern>^(([^:/?#]+):)?(//(([^@\[/?#]*)@)?(\[[[A-Fa-f0-9]\:\.]*[%[\p{L}\p{Nl}\p{Nd}]]*\]|[^\[/?#:]*)(:(\d*(?:\{[^/]+?\})?))?)?([^?#]*)(\?([^#]*))?(#(.*))?</sh:pattern>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:pattern>^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?</sh:pattern>
-        </rdf:Description>
-      </sh:and>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">emailAddress</sh:name>
-      <sh:description xml:lang="en">An e-mail address used for contacting the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/emailAddress"/>
-    </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the contact point.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
+    <rdfs:comment xml:lang="en">A contact point for an agent.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">phone</sh:name>
@@ -181,7 +182,6 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/phone"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">A contact point for an agent.</rdfs:comment>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/ConceptShape">
     <sh:property rdf:parseType="Resource">
@@ -264,11 +264,14 @@
     <rdfs:label xml:lang="en">Location Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">geometry</sh:name>
-      <sh:description xml:lang="en">Associates the Location with the corresponding Geometry.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/locn#geometry"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">geographic name</sh:name>
+      <sh:description xml:lang="en">A proper noun applied to a spatial object.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/geographicName"/>
     </sh:property>
+    <sh:targetClass rdf:resource="http://purl.org/dc/terms/Location"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">spatial code</sh:name>
@@ -276,13 +279,19 @@
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/spatialCode"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://purl.org/dc/terms/Location"/>
     <rdfs:comment xml:lang="en">An identifiable geographic place.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the location.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier</sh:name>
@@ -306,63 +315,18 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
     </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">geographic name</sh:name>
-      <sh:description xml:lang="en">A proper noun applied to a spatial object.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/geographicName"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the location.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+      <sh:name xml:lang="en">geometry</sh:name>
+      <sh:description xml:lang="en">Associates the Location with the corresponding Geometry.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/locn#geometry"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/AgentShape">
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">group member of</sh:name>
-      <sh:description xml:lang="en">The group the agent is a member of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <rdfs:label xml:lang="en">Agent Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">name</sh:name>
-      <sh:description xml:lang="en">The preferred name of the agent.</sh:description>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An identifier of the agent.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">publisher</sh:name>
@@ -379,13 +343,17 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the agent was last modified.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
     </sh:property>
+    <rdfs:label xml:lang="en">Agent Shape</rdfs:label>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">status</sh:name>
@@ -395,26 +363,21 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">An entity that is able to carry out actions.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">contact information</sh:name>
-      <sh:description xml:lang="en">The contact information of the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
-    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:name xml:lang="en">location</sh:name>
       <sh:description xml:lang="en">The location of the agent.</sh:description>
       <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">An entity that is able to carry out actions.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the agent was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:disjoint rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
@@ -424,30 +387,47 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
     </sh:property>
-  </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/EmailAddressShape">
-    <rdfs:label xml:lang="en">Email Address Shape</rdfs:label>
-    <rdfs:comment xml:lang="en">An e-mail address.</rdfs:comment>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">contact information</sh:name>
+      <sh:description xml:lang="en">The contact information of the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">group member of</sh:name>
+      <sh:description xml:lang="en">The group the agent is a member of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An identifier of the agent.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">name</sh:name>
+      <sh:description xml:lang="en">The preferred name of the agent.</sh:description>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/MediaObjectShape">
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">attachment type</sh:name>
-      <sh:description xml:lang="en">The type of the attachment of the media object. It should be provided using a controlled list, with values: Transcript of Records, EMREX transcript, Letter of Nomination,  Diploma Supplement, Certificate of Training, Learning Agreement, Other.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/attachmentType"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A media object.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">content</sh:name>
@@ -459,18 +439,49 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/content"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">content encoding</sh:name>
+      <sh:description xml:lang="en">The encoding used to encode the binary data. It should be provided using the EDC Controlled List of Content Encoding Types.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentEncoding"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en">The title of the media object. One value per language is permitted.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A media object.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">content size</sh:name>
+      <sh:description xml:lang="en">The content size of the media object.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentSize"/>
+    </sh:property>
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the media object.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+      <sh:name xml:lang="en">attachment type</sh:name>
+      <sh:description xml:lang="en">The type of the attachment of the media object. It should be provided using a controlled list, with values: Transcript of Records, EMREX transcript, Letter of Nomination,  Diploma Supplement, Certificate of Training, Learning Agreement, Other.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/attachmentType"/>
     </sh:property>
+    <rdfs:label xml:lang="en">Media Object Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">content type</sh:name>
@@ -486,47 +497,14 @@
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
       >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en">The title of the media object. One value per language is permitted.</sh:description>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the media object.</sh:description>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">content encoding</sh:name>
-      <sh:description xml:lang="en">The encoding used to encode the binary data. It should be provided using the EDC Controlled List of Content Encoding Types.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentEncoding"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Media Object Shape</rdfs:label>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">content size</sh:name>
-      <sh:description xml:lang="en">The content size of the media object.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentSize"/>
-    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/GroupShape">
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:description xml:lang="en">The name of the group.</sh:description>
-      <sh:name xml:lang="en">preferred name</sh:name>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-    </sh:property>
-    <rdfs:label xml:lang="en">Group Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">more information</sh:name>
@@ -534,21 +512,7 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The location of the group.</sh:description>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+    <rdfs:label xml:lang="en">Group Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">has member</sh:name>
@@ -563,6 +527,7 @@
       </sh:or>
       <sh:path rdf:resource="http://xmlns.com/foaf/0.1/member"/>
     </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">contact information</sh:name>
@@ -570,7 +535,13 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The location of the group.</sh:description>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:description xml:lang="en">The alternative name of the group.</sh:description>
@@ -578,29 +549,38 @@
       <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:description xml:lang="en">The name of the group.</sh:description>
+      <sh:name xml:lang="en">preferred name</sh:name>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+    </sh:property>
+    <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
+  </sh:NodeShape>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/MailboxShape">
+    <rdfs:label xml:lang="en">Mailbox Shape</rdfs:label>
+    <rdfs:comment xml:lang="en">A mailbox.</rdfs:comment>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/PhoneShape">
     <rdfs:comment xml:lang="en">A phone.</rdfs:comment>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">full phone number</sh:name>
-      <sh:description xml:lang="en">The full phone number as a string.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/phoneNumber"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">area dialling code</sh:name>
-      <sh:description xml:lang="en">The area dialling code for a contact number.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/areaDialing"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Phone Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">phone number</sh:name>
@@ -612,6 +592,20 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">full phone number</sh:name>
+      <sh:description xml:lang="en">The full phone number as a string.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/phoneNumber"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
+    <rdfs:label xml:lang="en">Phone Shape</rdfs:label>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">country dialling code</sh:name>
       <sh:description xml:lang="en">The country dialling code for a contact number.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -619,11 +613,17 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/countryDialing"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">area dialling code</sh:name>
+      <sh:description xml:lang="en">The area dialling code for a contact number.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/areaDialing"/>
+    </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/ConceptScheme">
     <rdfs:label xml:lang="en">Concept  Scheme Shape</rdfs:label>
@@ -633,15 +633,18 @@
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/AccreditationShape">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">limit abstract programme</sh:name>
-      <sh:description xml:lang="en">Abstract programme or qualification to which the accreditation applies. It should be provided using SKOS concept that represents the abstract programme. For example, if accreditation is valid for a specific abstract programme, such as 'Computer Science', this property can be used to specify that information.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitAbstractProgramme"/>
+      <sh:name xml:lang="en">publisher</sh:name>
+      <sh:description xml:lang="en">The publisher of the Accreditation.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
     </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <rdfs:label xml:lang="en">Accreditation Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">limit credential type</sh:name>
@@ -651,12 +654,46 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the accreditation. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Accreditation Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">review date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation has to be re-viewed.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/reviewDate"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accreditation date issued</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation was formally approved/issued.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accredited in jurisdiction</sh:name>
+      <sh:description xml:lang="en">The jurisdiction for which the accreditation is valid. It should be provided using the Administrative territorial unit Authority Table (ATU) controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">expiry date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation expires or was expired.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/expiryDate"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -669,21 +706,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An identifier of the accreditation, as assigned to it by the accrediting agent.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
       >true</sh:uniqueLang>
       <sh:name xml:lang="en">title</sh:name>
@@ -692,6 +714,13 @@
       >1</sh:minCount>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accredited for EQF level</sh:name>
+      <sh:description xml:lang="en">The European Qualification Framework level for which the accreditation is valid. It should be provided using the EQF controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitEQFLevel"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:node>
@@ -712,19 +741,45 @@
         </sh:NodeShape>
       </sh:node>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the accreditation.</sh:description>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A web resource containing additional documentation describing the Accreditation Procedures and Standards.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation was last updated since it was published.</sh:description>
+      <sh:name xml:lang="en">report</sh:name>
+      <sh:description xml:lang="en">A publicly accessible report of the quality assurance decision.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/report"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">decision</sh:name>
+      <sh:description xml:lang="en">The Quality Decision issued by the Quality Assuring Authority. It should be provided using a controlled list.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/decision"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An identifier of the accreditation, as assigned to it by the accrediting agent.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -737,6 +792,40 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">landing page</sh:name>
+      <sh:description xml:lang="en">The landing page of the accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/landingPage"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">The quality assurance or licensing of an organisation or a qualification. An accreditation instance can be used to specify information about: (1) the quality assurance and/or licensing of an organisation, (2) the quality assurance and/or licensing of an organisation with respect to a specific qualification.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">limit abstract programme</sh:name>
+      <sh:description xml:lang="en">Abstract programme or qualification to which the accreditation applies. It should be provided using SKOS concept that represents the abstract programme. For example, if accreditation is valid for a specific abstract programme, such as 'Computer Science', this property can be used to specify that information.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitAbstractProgramme"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/ams-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the accreditation. One value per language is permitted.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">status</sh:name>
       <sh:description xml:lang="en">The publication status of the accreditation.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -746,66 +835,14 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">landing page</sh:name>
-      <sh:description xml:lang="en">The landing page of the accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/landingPage"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">The quality assurance or licensing of an organisation or a qualification. An accreditation instance can be used to specify information about: (1) the quality assurance and/or licensing of an organisation, (2) the quality assurance and/or licensing of an organisation with respect to a specific qualification.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accredited for EQF level</sh:name>
-      <sh:description xml:lang="en">The European Qualification Framework level for which the accreditation is valid. It should be provided using the EQF controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitEQFLevel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">expiry date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation expires or was expired.</sh:description>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of accreditation. It should be provided using the EDC Controlled List of Accreditation Types controlled vocabulary.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/expiryDate"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">review date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation has to be re-viewed.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/reviewDate"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accredited in jurisdiction</sh:name>
-      <sh:description xml:lang="en">The jurisdiction for which the accreditation is valid. It should be provided using the Administrative territorial unit Authority Table (ATU) controlled vocabulary.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">publisher</sh:name>
-      <sh:description xml:lang="en">The publisher of the Accreditation.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -827,110 +864,53 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">report</sh:name>
-      <sh:description xml:lang="en">A publicly accessible report of the quality assurance decision.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/report"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">decision</sh:name>
-      <sh:description xml:lang="en">The Quality Decision issued by the Quality Assuring Authority. It should be provided using a controlled list.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/decision"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accreditation date issued</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation was formally approved/issued.</sh:description>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation was last updated since it was published.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/ams-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A web resource containing additional documentation describing the Accreditation Procedures and Standards.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of accreditation. It should be provided using the EDC Controlled List of Accreditation Types controlled vocabulary.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/OrganisationShape">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The legally registered site of the organisation.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">eIDAS identifier</sh:name>
-      <sh:description xml:lang="en">The official identification number of the organisation, as awarded by the relevant national authority.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/eidasLegalIdentifier"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the organisation.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">publisher</sh:name>
-      <sh:description xml:lang="en">The publisher of the organisation.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">registration</sh:name>
+      <sh:description xml:lang="en">The legal identifier of an organisation. The identifier given to a registered organisation by the authority with which it is registered. The legal status of a registered organisation is conferred on it by an authority within a given jurisdiction. The Legal Identifier is therefore a fundamental relationship between an organisation and the authority with which it is registered.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/regorg#registration"/>
     </sh:property>
     <rdfs:label xml:lang="en">Organisation Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">logo</sh:name>
-      <sh:description xml:lang="en">The logo of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the organisation.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/logo"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative identifier of the organisation.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -952,10 +932,47 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accreditation</sh:name>
-      <sh:description xml:lang="en">Accreditation records associated with the organisation. More information about the accreditation database is available here.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditation"/>
+      <sh:name xml:lang="en">parent organisation</sh:name>
+      <sh:description xml:lang="en">Indicates a larger organisation of which this organisation is a part of, e.g., the organisation within which a department operates.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#subOrganizationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">logo</sh:name>
+      <sh:description xml:lang="en">The logo of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/logo"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">contact information</sh:name>
+      <sh:description xml:lang="en">The contact information of an organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">eIDAS identifier</sh:name>
+      <sh:description xml:lang="en">The official identification number of the organisation, as awarded by the relevant national authority.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/eidasLegalIdentifier"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A registered organisation. Organisation is a subclass of Agent.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The legally registered site of the organisation.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/ams-constraints/URLRegexRestriction"/>
@@ -966,77 +983,12 @@
       <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
+      <sh:disjoint rdf:resource="http://www.w3.org/ns/regorg#legalName"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the organisation.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">group member of</sh:name>
-      <sh:description xml:lang="en">The group the organisation is a member of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">child organisation</sh:name>
-      <sh:description xml:lang="en">A smaller organisation of which forms part of this organisation, e.g., a department within a larger organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#hasSubOrganization"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">contact information</sh:name>
-      <sh:description xml:lang="en">The contact information of an organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A registered organisation. Organisation is a subclass of Agent.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the organisation.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">registration</sh:name>
-      <sh:description xml:lang="en">The legal identifier of an organisation. The identifier given to a registered organisation by the authority with which it is registered. The legal status of a registered organisation is conferred on it by an authority within a given jurisdiction. The Legal Identifier is therefore a fundamental relationship between an organisation and the authority with which it is registered.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/regorg#registration"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">tax/fiscal identifier</sh:name>
-      <sh:description xml:lang="en">Fiscal ID of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/taxIdentifier"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">parent organisation</sh:name>
-      <sh:description xml:lang="en">Indicates a larger organisation of which this organisation is a part of, e.g., the organisation within which a department operates.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#subOrganizationOf"/>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:description xml:lang="en">The alternative name of the organisation. It must be disjoint with legalName (rov:legalName) of the Organisation.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1048,12 +1000,60 @@
       <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
-      <sh:disjoint rdf:resource="http://www.w3.org/ns/regorg#legalName"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:description xml:lang="en">The alternative name of the organisation. It must be disjoint with legalName (rov:legalName) of the Organisation.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+      <sh:name xml:lang="en">accreditation</sh:name>
+      <sh:description xml:lang="en">Accreditation records associated with the organisation. More information about the accreditation database is available here.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditation"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">group member of</sh:name>
+      <sh:description xml:lang="en">The group the organisation is a member of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">tax/fiscal identifier</sh:name>
+      <sh:description xml:lang="en">Fiscal ID of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/taxIdentifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">child organisation</sh:name>
+      <sh:description xml:lang="en">A smaller organisation of which forms part of this organisation, e.g., a department within a larger organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#hasSubOrganization"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">publisher</sh:name>
+      <sh:description xml:lang="en">The publisher of the organisation.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative identifier of the organisation.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/NoteShape">
@@ -1094,24 +1094,9 @@
     >true</sh:closed>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/LegalIdentifierShape">
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme agency</sh:name>
-      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme version</sh:name>
-      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
-    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <rdfs:comment xml:lang="en">A Legal Identifier. Legal Identifier is a subclass of Identifier.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1124,15 +1109,42 @@
       <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#Literal"/>
       <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme name</sh:name>
-      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of identifier.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme version</sh:name>
+      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme ID </sh:name>
+      <sh:description xml:lang="en">Identification of the scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeId"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">scheme agency name</sh:name>
+      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1145,25 +1157,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme ID </sh:name>
-      <sh:description xml:lang="en">Identification of the scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeId"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of identifier.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">spatial</sh:name>
       <sh:description xml:lang="en">A spatial identifier. The identifier of the country and/or jurisdiction. It should be provided using the Country Named Authority List.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -1173,22 +1166,82 @@
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/spatial"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme name</sh:name>
+      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
+    </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
     <rdfs:label xml:lang="en">Legal Identifier Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">scheme agency name</sh:name>
-      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:name xml:lang="en">scheme agency</sh:name>
+      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
+      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/ams-constraints/IdentifierShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">date issued</sh:name>
+      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme name</sh:name>
+      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme version</sh:name>
+      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Identifier Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of identifier.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier content</sh:name>
+      <sh:description xml:lang="en">Content string which is the identifier.This property is used to assign a notation as a typed literal.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#Literal"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <rdfs:comment xml:lang="en">A character string used to identify a resource. An identifier is a character string used to uniquely identify one instance of an object within an identification scheme that is managed by an agency. The Identifier class is a critical aspect of the ELM. It is used to identify persons and organisations. In these cases and more, the identifier itself will be some sort of alpha-numeric string but that string only has meaning if it is contextualised.</rdfs:comment>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">scheme ID </sh:name>
@@ -1209,22 +1262,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of identifier.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">date issued</sh:name>
-      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
       >true</sh:uniqueLang>
       <sh:name xml:lang="en">scheme agency name</sh:name>
@@ -1233,43 +1270,6 @@
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Identifier Shape</rdfs:label>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-    <rdfs:comment xml:lang="en">A character string used to identify a resource. An identifier is a character string used to uniquely identify one instance of an object within an identification scheme that is managed by an agency. The Identifier class is a critical aspect of the ELM. It is used to identify persons and organisations. In these cases and more, the identifier itself will be some sort of alpha-numeric string but that string only has meaning if it is contextualised.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier content</sh:name>
-      <sh:description xml:lang="en">Content string which is the identifier.This property is used to assign a notation as a typed literal.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#Literal"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme name</sh:name>
-      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme version</sh:name>
-      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
     </sh:property>
   </sh:NodeShape>
 </rdf:RDF>

--- a/rdf/ap/edc/EDC-generic-no-cv.ttl
+++ b/rdf/ap/edc/EDC-generic-no-cv.ttl
@@ -816,7 +816,7 @@ edc:ContactPoint-elm_phone
 edc:ContactPoint-elm_emailAddress
   a sh:PropertyShape; 
   sh:path elm:emailAddress;
-  sh:class elm:EmailAddress;
+  sh:class elm:Mailbox;
   sh:description "An e-mail address used for contacting the agent."@en;
   sh:name "emailAddress"@en;
   sh:severity sh:Violation;
@@ -3762,12 +3762,12 @@ edc:LegalIdentifier-dc_spatial
   sh:severity sh:Violation;
   . 
 
-#------ EmailAddress class and properties shapes --------
-edc:EmailAddressShape
+#------ Mailbox class and properties shapes --------
+edc:MailboxShape
   a sh:NodeShape;
-  sh:targetClass elm:EmailAddress;
-  rdfs:comment "An e-mail address."@en;
-  rdfs:label "Email Address"@en;
+  sh:targetClass elm:Mailbox;
+  rdfs:comment "A mailbox."@en;
+  rdfs:label "Mailbox"@en;
   .
 
 #------ Media Object class and properties shapes --------

--- a/rdf/ap/edc/documentation/EDC-generic-no-cv.html
+++ b/rdf/ap/edc/documentation/EDC-generic-no-cv.html
@@ -249,7 +249,6 @@
             <li><a href="#edc:CreditPointShape">Credit Point </a></li>
             <li><a href="#edc:DisplayDetailShape">Display Detail </a></li>
             <li><a href="#edc:DisplayParameterShape">Display Parameter </a></li>
-            <li><a href="#edc:EmailAddressShape">Email Address</a></li>
             <li><a href="#edc:EuropeanDigitalCredentialShape">European Digital Credential </a></li>
             <li><a href="#edc:EuropeanDigitalPresentationShape">European Digital Presentation </a></li>
             <li><a href="#edc:EvidenceShape">Evidence </a></li>
@@ -272,6 +271,7 @@
             <li><a href="#edc:LearningOutcomeShape">Learning Outcome </a></li>
             <li><a href="#edc:LegalIdentifierShape">Legal Identifier </a></li>
             <li><a href="#edc:LocationShape">Location </a></li>
+            <li><a href="#edc:MailboxShape">Mailbox</a></li>
             <li><a href="#edc:MediaObjectShape">Media Object </a></li>
             <li><a href="#edc:NoteShape">Note </a></li>
             <li><a href="#edc:OrganisationShape">Organisation </a></li>
@@ -1293,7 +1293,7 @@
                 <tr>
                     <td>emailAddress</td>
                     <td><code><a href="http://data.europa.eu/snb/model/elm/emailAddress">elm:emailAddress</a></code></td>
-                    <td><code><a href="#edc:EmailAddressShape">Email Address</a></code><br></td>
+                    <td><code><a href="#edc:MailboxShape">Mailbox</a></code><br></td>
                     <td>
                         <div style="width:30px">0..*</div>
                     </td>
@@ -1488,18 +1488,6 @@
                 </tr>
                 </tbody>
             </table>
-        </section>
-    </div>
-</div><br><div class="row mt-3">
-    <div class="col">
-        <section id="edc:EmailAddressShape">
-            <div class="sp_section_title_table_wrapper">
-                <h2 class="sp_section_title_table">Email Address</h2>
-            </div>
-            <p><em>An e-mail address.</em></p>
-            <ul class="sp_list_description_properties">
-                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/EmailAddress">elm:EmailAddress</a></li>
-            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">
@@ -4491,6 +4479,18 @@
                 </tr>
                 </tbody>
             </table>
+        </section>
+    </div>
+</div><br><div class="row mt-3">
+    <div class="col">
+        <section id="edc:MailboxShape">
+            <div class="sp_section_title_table_wrapper">
+                <h2 class="sp_section_title_table">Mailbox</h2>
+            </div>
+            <p><em>A mailbox.</em></p>
+            <ul class="sp_list_description_properties">
+                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/Mailbox">elm:Mailbox</a></li>
+            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">

--- a/rdf/ap/edc/edc-ap-context.jsonld
+++ b/rdf/ap/edc/edc-ap-context.jsonld
@@ -49,7 +49,7 @@
         "LearningOutcome": "elm:LearningOutcome",
         "LegalIdentifier": "elm:LegalIdentifier",
         "Location": "dc:Location",
-        "EmailAddress": "elm:EmailAddress",
+        "Mailbox": "elm:Mailbox",
         "MediaObject": "elm:MediaObject",
         "Note": "elm:Note",
         "Organisation": "elm:Organisation",

--- a/rdf/ap/edc/rdf-xml/EDC-generic-no-cv.rdf
+++ b/rdf/ap/edc/rdf-xml/EDC-generic-no-cv.rdf
@@ -215,10 +215,12 @@
                   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/ClaimTypeNodeShape">
                     <sh:property rdf:parseType="Resource">
                       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-                      <sh:name xml:lang="en">more information</sh:name>
-                      <sh:description xml:lang="en">An additional free text note about the claim.</sh:description>
-                      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-                      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+                      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+                      >1</sh:minCount>
+                      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+                      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+                      <sh:name>type</sh:name>
+                      <sh:description xml:lang="en">When the claim (superclass is used) the type is mandatory.</sh:description>
                     </sh:property>
                     <sh:property rdf:parseType="Resource">
                       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -229,12 +231,10 @@
                     </sh:property>
                     <sh:property rdf:parseType="Resource">
                       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-                      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-                      >true</sh:uniqueLang>
-                      <sh:name xml:lang="en">description</sh:name>
-                      <sh:description xml:lang="en">A free text description of the claim.</sh:description>
-                      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-                      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+                      <sh:name xml:lang="en">more information</sh:name>
+                      <sh:description xml:lang="en">An additional free text note about the claim.</sh:description>
+                      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+                      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
                     </sh:property>
                     <sh:property rdf:parseType="Resource">
                       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -252,14 +252,12 @@
                     </sh:property>
                     <sh:property rdf:parseType="Resource">
                       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-                      <sh:name xml:lang="en">awarded by</sh:name>
-                      <sh:description xml:lang="en">The awarding details of the claim.</sh:description>
-                      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-                      >1</sh:maxCount>
-                      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-                      >1</sh:minCount>
-                      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/AwardingProcess"/>
-                      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/awardedBy"/>
+                      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                      >true</sh:uniqueLang>
+                      <sh:name xml:lang="en">description</sh:name>
+                      <sh:description xml:lang="en">A free text description of the claim.</sh:description>
+                      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+                      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
                     </sh:property>
                     <rdfs:comment xml:lang="en">This shape does not apply on a class. This shape checks if a node is a Claim (when used directly and not via one of its subclasses),  having type as a mandatory property.</rdfs:comment>
                     <rdfs:label xml:lang="en">Claim Type Node </rdfs:label>
@@ -276,12 +274,14 @@
                     </sh:property>
                     <sh:property rdf:parseType="Resource">
                       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+                      <sh:name xml:lang="en">awarded by</sh:name>
+                      <sh:description xml:lang="en">The awarding details of the claim.</sh:description>
+                      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+                      >1</sh:maxCount>
                       <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
                       >1</sh:minCount>
-                      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-                      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-                      <sh:name>type</sh:name>
-                      <sh:description xml:lang="en">When the claim (superclass is used) the type is mandatory.</sh:description>
+                      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/AwardingProcess"/>
+                      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/awardedBy"/>
                     </sh:property>
                   </sh:NodeShape>
                 </sh:node>
@@ -1211,39 +1211,6 @@
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/GroupShape">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:description xml:lang="en">The alternative name of the group.</sh:description>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:description xml:lang="en">The preferred name of the group.</sh:description>
-      <sh:name xml:lang="en">preferred name</sh:name>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The location of the group.</sh:description>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">has member</sh:name>
       <sh:description xml:lang="en">An agent being a member of the group.</sh:description>
       <sh:or rdf:parseType="Collection">
@@ -1259,7 +1226,14 @@
       </sh:or>
       <sh:path rdf:resource="http://xmlns.com/foaf/0.1/member"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Group </rdfs:label>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The location of the group.</sh:description>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">contact information</sh:name>
@@ -1267,13 +1241,39 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:description xml:lang="en">The preferred name of the group.</sh:description>
+      <sh:name xml:lang="en">preferred name</sh:name>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Group </rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">more information</sh:name>
       <sh:description xml:lang="en">An additional free text note about the group.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:description xml:lang="en">The alternative name of the group.</sh:description>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/LearningOutcomeShape">
@@ -3009,11 +3009,6 @@
       </sh:PropertyShape>
     </sh:property>
   </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/EmailAddressShape">
-    <rdfs:label xml:lang="en">Email Address</rdfs:label>
-    <rdfs:comment xml:lang="en">An e-mail address.</rdfs:comment>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
-  </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/ContactPointShape">
     <sh:property>
       <sh:PropertyShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/ContactPoint-dc_description">
@@ -3070,7 +3065,7 @@
         <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
         <sh:name xml:lang="en">emailAddress</sh:name>
         <sh:description xml:lang="en">An e-mail address used for contacting the agent.</sh:description>
-        <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
+        <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
         <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/emailAddress"/>
       </sh:PropertyShape>
     </sh:property>
@@ -3535,6 +3530,11 @@
         <sh:path rdf:resource="http://purl.org/dc/terms/spatial"/>
       </sh:PropertyShape>
     </sh:property>
+  </sh:NodeShape>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/MailboxShape">
+    <rdfs:label xml:lang="en">Mailbox</rdfs:label>
+    <rdfs:comment xml:lang="en">A mailbox.</rdfs:comment>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-no-cv/EuropeanDigitalPresentationShape">
     <sh:property>

--- a/rdf/ap/loq/LOQ-constraints.ttl
+++ b/rdf/ap/loq/LOQ-constraints.ttl
@@ -418,15 +418,15 @@ a owl:Ontology;
   .
 
 #-------------------------------------------------------------------------
-#--------------- EmailAddress class and property  shapes ----------------------
+#--------------- Mailbox class and property  shapes ----------------------
 #-------------------------------------------------------------------------
-:EmailAddressShape
+:MailboxShape
   a sh:NodeShape;
   sh:closed true ;
   sh:ignoredProperties (rdf:type) ;
-  sh:targetClass elm:EmailAddress;
-  rdfs:comment "An e-mail address."@en;
-  rdfs:label "Email Address Shape"@en;
+  sh:targetClass elm:Mailbox;
+  rdfs:comment "A mailbox."@en;
+  rdfs:label "Mailbox Shape"@en;
   .
 
 #-------------------------------------------------------------------------
@@ -658,7 +658,7 @@ a owl:Ontology;
   ];
   sh:property [
     sh:path elm:emailAddress;
-    sh:class elm:EmailAddress;
+    sh:class elm:Mailbox;
     sh:description "An e-mail address used for contacting the agent."@en;
     sh:name "emailAddress"@en;
     sh:severity sh:Violation;

--- a/rdf/ap/loq/documentation/LOQ-constraints.html
+++ b/rdf/ap/loq/documentation/LOQ-constraints.html
@@ -244,7 +244,6 @@
             <li><a href="#:ConceptShape">Concept Shape</a></li>
             <li><a href="#:ContactPointShape">Contact Point Shape</a></li>
             <li><a href="#:CreditPointShape">Credit Points Shape</a></li>
-            <li><a href="#:EmailAddressShape">Email Address Shape</a></li>
             <li><a href="#:GeometryShape">Geometry Shape</a></li>
             <li><a href="#:GradingSchemeShape">Grading Scheme Shape</a></li>
             <li><a href="#:GrantShape">Grant Shape</a></li>
@@ -258,6 +257,7 @@
             <li><a href="#:LearningOutcomeShape">Learning Outcome Shape</a></li>
             <li><a href="#:LegalIdentifierShape">Legal Identifier Shape</a></li>
             <li><a href="#:LocationShape">Location Shape</a></li>
+            <li><a href="#:MailboxShape">Mailbox Shape</a></li>
             <li><a href="#:MediaObjectShape">Media Object Shape</a></li>
             <li><a href="#:NoteShape">Note Shape</a></li>
             <li><a href="#:OrganisationShape">Organisation Shape</a></li>
@@ -991,7 +991,7 @@
                 <tr>
                     <td>emailAddress</td>
                     <td><code><a href="http://data.europa.eu/snb/model/elm/emailAddress">elm:emailAddress</a></code></td>
-                    <td><code><a href="#:EmailAddressShape">Email Address Shape</a></code><br></td>
+                    <td><code><a href="#:MailboxShape">Mailbox Shape</a></code><br></td>
                     <td>
                         <div style="width:30px">0..*</div>
                     </td>
@@ -1062,19 +1062,6 @@
                 </tr>
                 </tbody>
             </table>
-        </section>
-    </div>
-</div><br><div class="row mt-3">
-    <div class="col">
-        <section id=":EmailAddressShape">
-            <div class="sp_section_title_table_wrapper">
-                <h2 class="sp_section_title_table">Email Address Shape</h2>
-            </div>
-            <p><em>An e-mail address.</em></p>
-            <ul class="sp_list_description_properties">
-                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/EmailAddress">elm:EmailAddress</a></li>
-                <li>Closed shape</li>
-            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">
@@ -3025,6 +3012,19 @@
                 </tr>
                 </tbody>
             </table>
+        </section>
+    </div>
+</div><br><div class="row mt-3">
+    <div class="col">
+        <section id=":MailboxShape">
+            <div class="sp_section_title_table_wrapper">
+                <h2 class="sp_section_title_table">Mailbox Shape</h2>
+            </div>
+            <p><em>A mailbox.</em></p>
+            <ul class="sp_list_description_properties">
+                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/Mailbox">elm:Mailbox</a></li>
+                <li>Closed shape</li>
+            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">

--- a/rdf/ap/loq/rdf-xml/LOQ-constraints.rdf
+++ b/rdf/ap/loq/rdf-xml/LOQ-constraints.rdf
@@ -80,6 +80,15 @@
     >true</sh:closed>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LearningOutcomeShape">
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningOutcome"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the learning outcome.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A statement regarding what a learner knows, understands and is able to do on completion of a learning process, which are defined in terms of knowledge, skills and responsibility and autonomy.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">type</sh:name>
@@ -89,26 +98,21 @@
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningOutcome"/>
-    <rdfs:comment xml:lang="en">A statement regarding what a learner knows, understands and is able to do on completion of a learning process, which are defined in terms of knowledge, skills and responsibility and autonomy.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">related skill(s)</sh:name>
-      <sh:description xml:lang="en">A link to a related skill or the level of a related skill on a skill framework (except ESCO). It should be provided using a controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/relatedSkill"/>
-    </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">related ESCO skill(s)</sh:name>
-      <sh:description xml:lang="en">A link to an ESCO  skill. It should be provided using the ESCO skills controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/relatedESCOSkill"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative identifier of the learning outcome.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -130,51 +134,40 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
     </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <rdfs:label xml:lang="en">Learning Outcome Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the learning outcome.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+      <sh:name xml:lang="en">related skill(s)</sh:name>
+      <sh:description xml:lang="en">A link to a related skill or the level of a related skill on a skill framework (except ESCO). It should be provided using a controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/relatedSkill"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative identifier of the learning outcome.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+      <sh:name xml:lang="en">related ESCO skill(s)</sh:name>
+      <sh:description xml:lang="en">A link to an ESCO  skill. It should be provided using the ESCO skills controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/relatedESCOSkill"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/GroupShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The location of the group.</sh:description>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
     <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">has member</sh:name>
-      <sh:description xml:lang="en">An agent being a member of the group.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/member"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:description xml:lang="en">The alternative name of the group.</sh:description>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
     </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
     <sh:property rdf:parseType="Resource">
@@ -195,20 +188,27 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">has member</sh:name>
+      <sh:description xml:lang="en">An agent being a member of the group.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/member"/>
+    </sh:property>
     <rdfs:label xml:lang="en">Group Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:description xml:lang="en">The alternative name of the group.</sh:description>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The location of the group.</sh:description>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -221,6 +221,9 @@
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/PhoneShape">
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">full phone number</sh:name>
@@ -230,15 +233,8 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/phoneNumber"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">country dialling code</sh:name>
-      <sh:description xml:lang="en">The country dialling code for a contact number.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/countryDialing"/>
-    </sh:property>
+    <rdfs:label xml:lang="en">Phone Shape</rdfs:label>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">area dialling code</sh:name>
@@ -248,12 +244,6 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/areaDialing"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Phone Shape</rdfs:label>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
-    <rdfs:comment xml:lang="en">A phone.</rdfs:comment>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">phone number</sh:name>
@@ -262,6 +252,16 @@
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/dialNumber"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A phone.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">country dialling code</sh:name>
+      <sh:description xml:lang="en">The country dialling code for a contact number.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/countryDialing"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/SpecificationNodeShape">
@@ -307,139 +307,6 @@
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LearningOpportunityShape">
     <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">application deadline</sh:name>
-      <sh:description xml:lang="en">The deadline for applying to the course.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/applicationDeadline"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">has part</sh:name>
-      <sh:description xml:lang="en">A learning opportunity can be composed of other learning opportunities, which when combined make up this larger learning opportunity.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOpportunity"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">admissions procedure</sh:name>
-      <sh:description xml:lang="en">Specific information on how to apply for the course.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/admissionProcedure"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the Learning Opportunity.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">fees</sh:name>
-      <sh:description xml:lang="en">Information about the pricing of the course, including fees and scholarships/subsidies available.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/PriceDetail"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/priceDetail"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">banner image</sh:name>
-      <sh:description xml:lang="en">An image which is displayed alongside the learning opportunity.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/bannerImage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">mode</sh:name>
-      <sh:description xml:lang="en">The mode of learning Opportunity. It should be provided using the EDC Controlled List of Modes Of Learning and Assessment. </sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">grant</sh:name>
-      <sh:description xml:lang="en">The grant related to the learning opportunity.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Grant"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/grant"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en"> The title of Learning Opportunity. One value per language is permitted.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">learning schedule</sh:name>
-      <sh:description xml:lang="en">The learning schedule. It should be provided using the EDC Controlled List of Learning Schedule Types.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningSchedule"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">publisher</sh:name>
-      <sh:description xml:lang="en">The publisher of the Learning Opportunity.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">duration</sh:name>
-      <sh:description xml:lang="en">The nominal duration for which the learning opportunity will continue to run. Note, this may be after the end-date, since admissions may be closed but the learning opportunity may still be ongoing.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/duration"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">temporal</sh:name>
-      <sh:description xml:lang="en">The associated period of time shape.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://purl.org/dc/terms/PeriodOfTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/temporal"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative Identifier of the Learning Opportunity.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
       <sh:name xml:lang="en">learning achievement specification</sh:name>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
@@ -461,14 +328,36 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the learning opportunity was last modified.</sh:description>
+      <sh:name xml:lang="en">has part</sh:name>
+      <sh:description xml:lang="en">A learning opportunity can be composed of other learning opportunities, which when combined make up this larger learning opportunity.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOpportunity"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">admissions procedure</sh:name>
+      <sh:description xml:lang="en">Specific information on how to apply for the course.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/admissionProcedure"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">An opportunity to realise a given set of learning outcomes via a learning activity and/or assessment.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en"> The type of the learning opportunity. It should be provided using the EDC Controlled List of Learning Opportunity Types.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the learning opportunity.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">provided by</sh:name>
@@ -478,6 +367,15 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/providedBy"/>
     </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">fees</sh:name>
+      <sh:description xml:lang="en">Information about the pricing of the course, including fees and scholarships/subsidies available.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/PriceDetail"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/priceDetail"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:name xml:lang="en">location</sh:name>
       <sh:description xml:lang="en">The location where the learning opportunity was provided at.</sh:description>
@@ -486,12 +384,128 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en"> The type of the learning opportunity. It should be provided using the EDC Controlled List of Learning Opportunity Types.</sh:description>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the learning opportunity was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the Learning Opportunity.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:name xml:lang="en">learning activity specification</sh:name>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:description xml:lang="en"> The learning activity specification, including the curricula, of this learning opportunity.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningActivitySpecification"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">An opportunity to realise a given set of learning outcomes via a learning activity and/or assessment.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">duration</sh:name>
+      <sh:description xml:lang="en">The nominal duration for which the learning opportunity will continue to run. Note, this may be after the end-date, since admissions may be closed but the learning opportunity may still be ongoing.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/duration"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">application deadline</sh:name>
+      <sh:description xml:lang="en">The deadline for applying to the course.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/applicationDeadline"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">temporal</sh:name>
+      <sh:description xml:lang="en">The associated period of time shape.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://purl.org/dc/terms/PeriodOfTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/temporal"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">publisher</sh:name>
+      <sh:description xml:lang="en">The publisher of the Learning Opportunity.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">default language</sh:name>
+      <sh:description xml:lang="en">The base language of the learning opportunity, to be considered authoritative.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/defaultLanguage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">learning schedule</sh:name>
+      <sh:description xml:lang="en">The learning schedule. It should be provided using the EDC Controlled List of Learning Schedule Types.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningSchedule"/>
     </sh:property>
     <rdfs:label xml:lang="en">Learning Opportunity Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">banner image</sh:name>
+      <sh:description xml:lang="en">An image which is displayed alongside the learning opportunity.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/bannerImage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative Identifier of the Learning Opportunity.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">is part of</sh:name>
+      <sh:description xml:lang="en">A learning opportunity can be part of other learning opportunity.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOpportunity"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">mode</sh:name>
+      <sh:description xml:lang="en">The mode of learning Opportunity. It should be provided using the EDC Controlled List of Modes Of Learning and Assessment. </sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -503,19 +517,23 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en"> The title of Learning Opportunity. One value per language is permitted.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">schedule information</sh:name>
       <sh:description xml:lang="en">Detailed information about the timetable or schedule. This may include weekly schedules (e.g., 'Every Monday, 4pm', but may also include the overall schedule for the course, (e.g., October: lectures, November: group-work, December: break, January: assessment).</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/scheduleInformation"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">is part of</sh:name>
-      <sh:description xml:lang="en">A learning opportunity can be part of other learning opportunity.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOpportunity"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:node>
@@ -536,42 +554,6 @@
         </sh:NodeShape>
       </sh:node>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web document containing additional documentation about the Learning Opportunity.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:name xml:lang="en">learning activity specification</sh:name>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:description xml:lang="en"> The learning activity specification, including the curricula, of this learning opportunity.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningActivitySpecification"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">default language</sh:name>
-      <sh:description xml:lang="en">The base language of the learning opportunity, to be considered authoritative.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/defaultLanguage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the learning opportunity.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">homepage</sh:name>
       <sh:description xml:lang="en">The homepage.</sh:description>
       <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -579,10 +561,31 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
       <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web document containing additional documentation about the Learning Opportunity.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">grant</sh:name>
+      <sh:description xml:lang="en">The grant related to the learning opportunity.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Grant"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/grant"/>
+    </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningOpportunity"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LegalIdentifierShape">
     <rdfs:label xml:lang="en">Legal Identifier Shape</rdfs:label>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <rdfs:comment xml:lang="en">A legal identifier. A legal identifier is a formally issued identifier by a given authority within a given jurisdiction. The identifier has a spatial context. Legal Identifier is a subclass of Identifier.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">scheme name</sh:name>
@@ -594,28 +597,32 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">date issued</sh:name>
-      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
+      <sh:name xml:lang="en">scheme version</sh:name>
+      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <rdfs:comment xml:lang="en">A legal identifier. A legal identifier is a formally issued identifier by a given authority within a given jurisdiction. The identifier has a spatial context. Legal Identifier is a subclass of Identifier.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier content</sh:name>
-      <sh:description xml:lang="en">Content string which is the identifier. This property is used to assign a notation as a typed literal.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#Literal"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
     </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme agency name</sh:name>
+      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme agency</sh:name>
+      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">spatial</sh:name>
@@ -629,40 +636,19 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme agency name</sh:name>
-      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:name xml:lang="en">date issued</sh:name>
+      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme version</sh:name>
-      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">type</sh:name>
       <sh:description xml:lang="en">The type of the identifier.</sh:description>
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme agency</sh:name>
-      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -673,8 +659,25 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeId"/>
     </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier content</sh:name>
+      <sh:description xml:lang="en">Content string which is the identifier. This property is used to assign a notation as a typed literal.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#Literal"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
+    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/GrantShape">
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">URL</sh:name>
@@ -683,25 +686,6 @@
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentUrl"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en"> The type of the grant.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web document containing additional documentation about the grant.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
     </sh:property>
     <rdfs:comment xml:lang="en">The Grant.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
@@ -715,9 +699,19 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en"> The type of the grant.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Grant"/>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
+    <rdfs:label xml:lang="en">Grant Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -727,7 +721,13 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Grant Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web document containing additional documentation about the grant.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/AmountShape">
     <sh:property rdf:parseType="Resource">
@@ -762,205 +762,6 @@
     >true</sh:closed>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LearningAchievementSpecificationShape">
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">generalisation of</sh:name>
-      <sh:description xml:lang="en">A learning achievement specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the learning achievement specification. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">specialisation of</sh:name>
-      <sh:description xml:lang="en">A learning  achievement specification (e.g., a standard) of which this specification is a specialisation.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/specialisationOf"/>
-    </sh:property>
-    <sh:deactivated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:deactivated>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:description xml:lang="en">The alternative name of the learning achievement specification.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the learning achievement specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">learning setting</sh:name>
-      <sh:description xml:lang="en">The type of learning setting (formal, non-formal). It should be provided using the EDC Controlled List of Learning Setting Types.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningSetting"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">education subject</sh:name>
-      <sh:description xml:lang="en">An associated field of education from another semantic framework than the ISCED classification.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationSubject"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">learning outcome summary</sh:name>
-      <sh:description xml:lang="en">The full learning outcome summary of the learning achievement specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcomeSummary"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">influenced by</sh:name>
-      <sh:description xml:lang="en">Activities that a person can perform to acquire the expected learning outcomes.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/influencedBy"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Learning Achievement Specification Shape</rdfs:label>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <rdfs:comment xml:lang="en">A description of what a person may learn using the opportunity, expressed as learning outcomes. A specification of learning achievement. Learning Achievement Specification is a subclass of Specification.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">mode</sh:name>
-      <sh:description xml:lang="en">The mode of learning, and or assessment. It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">target group</sh:name>
-      <sh:description xml:lang="en">A specific target group or category for which this specification is designed. It should be provided using the EDC Controlled List of Target Groups.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/targetGroup"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">is part of </sh:name>
-      <sh:description xml:lang="en">A learning achievement specification, which this learning achievement specification is part of.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web resource containing additional documentation about the learning achievement specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en"> The title of the learning achievement specification. One value per language is permitted.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">entry requirement</sh:name>
-      <sh:description xml:lang="en">Specific entry requirement or prerequisite of individuals for which this specification is designed to start this learning opportunity.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entryRequirement"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">education level</sh:name>
-      <sh:description xml:lang="en">An associated level of education within a semantic framework describing education levels.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationLevel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative identifier of the learning achievement specification.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">proven by</sh:name>
-      <sh:description xml:lang="en">Assessments a person can undergo to prove the acquisition of the learning outcomes.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/provenBy"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">category</sh:name>
-      <sh:description xml:lang="en">The category of the learning achievement specification provided as a string.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">credit points</sh:name>
-      <sh:description xml:lang="en">The credit points assigned to the learning achievement specification, following an educational credit system.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/CreditPoint"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/creditPoint"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en"> A free text description of the learning achievement specification. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">learning outcome</sh:name>
@@ -970,62 +771,6 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOutcome"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcome"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the learning achievement specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">thematic area</sh:name>
-      <sh:description xml:lang="en">The thematic area according to the ISCED-F 2013 Classification. It should be provided using the ISCEDF controlled vocabulary.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/ISCEDFCode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en"> An additional free text note about the learning achievement specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">language</sh:name>
-      <sh:description xml:lang="en">The language of the learning achievement specification. It should be provided using the Language Named Authority List.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/language"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">entitles to</sh:name>
-      <sh:description xml:lang="en">Rights (such as which the person may acquire as a result of acquiring the learning outcomes).</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitlesTo"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">awarding information</sh:name>
-      <sh:description xml:lang="en">Refers to an activity related to the awarding of the learning specification, such as the country or region where the qualification is awarded, the awarding body and optionally the awarding period now or in the past.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/AwardingOpportunity"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/awardingOpportunity"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">volume of learning</sh:name>
-      <sh:description xml:lang="en">The estimated number of hours the learner is expected to spend engaged in learning to earn the award. This would include the notional number of hours in class, in group work, in practicals, as well as hours engaged in self-motivated study.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/volumeOfLearning"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">publisher</sh:name>
@@ -1043,6 +788,108 @@
       <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web resource containing additional documentation about the learning achievement specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the learning achievement specification. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:deactivated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:deactivated>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en"> A free text description of the learning achievement specification. One value per language is permitted.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">credit points</sh:name>
+      <sh:description xml:lang="en">The credit points assigned to the learning achievement specification, following an educational credit system.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/CreditPoint"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/creditPoint"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:description xml:lang="en">The alternative name of the learning achievement specification.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en"> The title of the learning achievement specification. One value per language is permitted.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Learning Achievement Specification Shape</rdfs:label>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <rdfs:comment xml:lang="en">A description of what a person may learn using the opportunity, expressed as learning outcomes. A specification of learning achievement. Learning Achievement Specification is a subclass of Specification.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">entry requirement</sh:name>
+      <sh:description xml:lang="en">Specific entry requirement or prerequisite of individuals for which this specification is designed to start this learning opportunity.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entryRequirement"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative identifier of the learning achievement specification.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">category</sh:name>
+      <sh:description xml:lang="en">The category of the learning achievement specification provided as a string.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">target group</sh:name>
+      <sh:description xml:lang="en">A specific target group or category for which this specification is designed. It should be provided using the EDC Controlled List of Target Groups.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/targetGroup"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">influenced by</sh:name>
+      <sh:description xml:lang="en">Activities that a person can perform to acquire the expected learning outcomes.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/influencedBy"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">maximum duration</sh:name>
       <sh:description xml:lang="en">The maximum duration (in months) that a person may use to complete the learning opportunity for which this learning achievement specification is designed.</sh:description>
@@ -1053,12 +900,165 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">is part of </sh:name>
+      <sh:description xml:lang="en">A learning achievement specification, which this learning achievement specification is part of.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">volume of learning</sh:name>
+      <sh:description xml:lang="en">The estimated number of hours the learner is expected to spend engaged in learning to earn the award. This would include the notional number of hours in class, in group work, in practicals, as well as hours engaged in self-motivated study.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/volumeOfLearning"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">language</sh:name>
+      <sh:description xml:lang="en">The language of the learning achievement specification. It should be provided using the Language Named Authority List.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/language"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">education subject</sh:name>
+      <sh:description xml:lang="en">An associated field of education from another semantic framework than the ISCED classification.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationSubject"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">generalisation of</sh:name>
+      <sh:description xml:lang="en">A learning achievement specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">mode</sh:name>
+      <sh:description xml:lang="en">The mode of learning, and or assessment. It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">education level</sh:name>
+      <sh:description xml:lang="en">An associated level of education within a semantic framework describing education levels.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationLevel"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the learning achievement specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">proven by</sh:name>
+      <sh:description xml:lang="en">Assessments a person can undergo to prove the acquisition of the learning outcomes.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/provenBy"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">entitles to</sh:name>
+      <sh:description xml:lang="en">Rights (such as which the person may acquire as a result of acquiring the learning outcomes).</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitlesTo"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">learning setting</sh:name>
+      <sh:description xml:lang="en">The type of learning setting (formal, non-formal). It should be provided using the EDC Controlled List of Learning Setting Types.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningSetting"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">learning outcome summary</sh:name>
+      <sh:description xml:lang="en">The full learning outcome summary of the learning achievement specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcomeSummary"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">thematic area</sh:name>
+      <sh:description xml:lang="en">The thematic area according to the ISCED-F 2013 Classification. It should be provided using the ISCEDF controlled vocabulary.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/ISCEDFCode"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the learning achievement specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">last modification date</sh:name>
       <sh:description xml:lang="en">The date when the learning achievement specification was last modified.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">specialisation of</sh:name>
+      <sh:description xml:lang="en">A learning  achievement specification (e.g., a standard) of which this specification is a specialisation.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAchievementSpecification"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/specialisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">awarding information</sh:name>
+      <sh:description xml:lang="en">Refers to an activity related to the awarding of the learning specification, such as the country or region where the qualification is awarded, the awarding body and optionally the awarding period now or in the past.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/AwardingOpportunity"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/awardingOpportunity"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en"> An additional free text note about the learning achievement specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1114,6 +1114,10 @@
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/AwardingOpportunityShape">
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/AwardingOpportunity"/>
+    <rdfs:label xml:lang="en">Awarding Opportunity Shape</rdfs:label>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier</sh:name>
@@ -1127,6 +1131,16 @@
         </rdf:Description>
       </sh:or>
       <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">An awarding opportunity describes how, where, from whom and when a claim may be obtained.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">temporal</sh:name>
+      <sh:description xml:lang="en"> The temporal duration, associated with a period of time, when the awarding activities take place. If not specified it is undefined (“not known”).</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://purl.org/dc/terms/PeriodOfTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/temporal"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1144,11 +1158,6 @@
       </sh:or>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/awardingBody"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Awarding Opportunity Shape</rdfs:label>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <rdfs:comment xml:lang="en">An awarding opportunity describes how, where, from whom and when a claim may be obtained.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">awarded learning achievement specification</sh:name>
@@ -1167,15 +1176,6 @@
       </sh:or>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningAchievementSpecification"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">temporal</sh:name>
-      <sh:description xml:lang="en"> The temporal duration, associated with a period of time, when the awarding activities take place. If not specified it is undefined (“not known”).</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://purl.org/dc/terms/PeriodOfTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/temporal"/>
-    </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
     <sh:property rdf:parseType="Resource">
@@ -1189,24 +1189,9 @@
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/IdentifierShape">
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme agency</sh:name>
-      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme agency name</sh:name>
-      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
-    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
     <rdfs:comment xml:lang="en">A character string used to identify a resource. An identifier is a character string used to uniquely identify one instance of an object within an identification scheme that is managed by an agency. The Identifier class is a critical aspect of the ELM. It is used to identify persons and organisations. In these cases, and more, the identifier itself will be some sort of alpha-numeric string but that string only has meaning if it is contextualised.</rdfs:comment>
@@ -1221,6 +1206,43 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme ID </sh:name>
+      <sh:description xml:lang="en">Identification of the scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeId"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme version</sh:name>
+      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Identifier Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme agency name</sh:name>
+      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme agency</sh:name>
+      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier content</sh:name>
       <sh:description xml:lang="en">Content string which is the identifier. This property is used to assign a notation as a typed literal</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -1232,14 +1254,11 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme ID </sh:name>
-      <sh:description xml:lang="en">Identification of the scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeId"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the identifier.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Identifier Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">scheme name</sh:name>
@@ -1249,56 +1268,50 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
     </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the identifier.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme version</sh:name>
-      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
-    </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/OrganisationShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">VAT number</sh:name>
+      <sh:description xml:lang="en">The Value-Added Tax ID.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/vatIdentifier"/>
+    </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">tax/fiscal identifier</sh:name>
-      <sh:description xml:lang="en">Fiscal ID of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/taxIdentifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">child organisation</sh:name>
-      <sh:description xml:lang="en">A smaller organisation of which forms part of this organisation, e.g., a department within a larger organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#hasSubOrganization"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">registration</sh:name>
-      <sh:description xml:lang="en">The legal identifier of an organisation. The identifier given to a registered organisation by the authority with which it is registered. The legal status of a registered organisation is conferred on it by an authority within a given jurisdiction. The Legal Identifier is therefore a fundamental relationship between an organisation and the authority with which it is registered.</sh:description>
+      <sh:name xml:lang="en">eIDAS identifier</sh:name>
+      <sh:description xml:lang="en">The official identification number of the organisation, as awarded by the relevant national authority.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/regorg#registration"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/eidasLegalIdentifier"/>
     </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">logo</sh:name>
+      <sh:description xml:lang="en">The logo of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/logo"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative identifier of the organisation.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">publisher</sh:name>
@@ -1317,18 +1330,72 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative identifier of the organisation.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the organisation.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">child organisation</sh:name>
+      <sh:description xml:lang="en">A smaller organisation of which forms part of this organisation, e.g., a department within a larger organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#hasSubOrganization"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">registration</sh:name>
+      <sh:description xml:lang="en">The legal identifier of an organisation. The identifier given to a registered organisation by the authority with which it is registered. The legal status of a registered organisation is conferred on it by an authority within a given jurisdiction. The Legal Identifier is therefore a fundamental relationship between an organisation and the authority with which it is registered.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/regorg#registration"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the organisation was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">tax/fiscal identifier</sh:name>
+      <sh:description xml:lang="en">Fiscal ID of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/taxIdentifier"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Organisation Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">parent organisation</sh:name>
+      <sh:description xml:lang="en">Indicates a larger organisation of which this organisation is a part of, e.g., the organisation within which a department operates.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#subOrganizationOf"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A legal person / registered organisation. Organisation is a subclass of Agent.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -1342,6 +1409,13 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accreditation</sh:name>
+      <sh:description xml:lang="en">An associated accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditation"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">status</sh:name>
       <sh:description xml:lang="en">The publication status of the organisation.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -1349,39 +1423,12 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Organisation Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">eIDAS identifier</sh:name>
-      <sh:description xml:lang="en">The official identification number of the organisation, as awarded by the relevant national authority.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/eidasLegalIdentifier"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A legal person / registered organisation. Organisation is a subclass of Agent.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">group member of</sh:name>
       <sh:description xml:lang="en">The group the organisation  is a member of.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">parent organisation</sh:name>
-      <sh:description xml:lang="en">Indicates a larger organisation of which this organisation is a part of, e.g., the organisation within which a department operates.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#subOrganizationOf"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1392,13 +1439,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the organisation.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">location</sh:name>
       <sh:description xml:lang="en">The location of the organisation.</sh:description>
       <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -1406,47 +1446,7 @@
       <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">VAT number</sh:name>
-      <sh:description xml:lang="en">The Value-Added Tax ID.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/vatIdentifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accreditation</sh:name>
-      <sh:description xml:lang="en">An associated accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditation"/>
-    </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">logo</sh:name>
-      <sh:description xml:lang="en">The logo of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/logo"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the organisation was last modified.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
-    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:disjoint rdf:resource="http://www.w3.org/ns/regorg#legalName"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1457,66 +1457,39 @@
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LearningAssessmentSpecificationShape">
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
       >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en"> The title of the learning assessment specification. One value per language is permitted.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en"> A free text description of the learning assessment specification. One value per language is permitted.</sh:description>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web resource containing additional documentation about the learning assessment specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative label</sh:name>
-      <sh:description xml:lang="en">The alternative name of the learning assessment specification.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the learning assessment specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the learning assessment specification.</sh:description>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the learning assessment specification was last modified.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">is part of</sh:name>
-      <sh:description xml:lang="en">A learning assessment specification, which this learning assessment specification is part of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">language</sh:name>
-      <sh:description xml:lang="en">The language of instruction.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/language"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">mode</sh:name>
-      <sh:description xml:lang="en">The mode of learning and or assessment (i.e., online, blended, presential, work based). It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">category</sh:name>
-      <sh:description xml:lang="en">The category of the learning assessment specification provided as a string.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Learning Assessment Specification Shape</rdfs:label>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">proves</sh:name>
@@ -1536,45 +1509,29 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the learning assessment specification was last modified.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:name xml:lang="en">language</sh:name>
+      <sh:description xml:lang="en">The language of instruction.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/language"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">publisher</sh:name>
-      <sh:description xml:lang="en">The publisher of the learning assessment specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A Learning  Assessment Specification is a specification of a process establishing the extent to which a learner has attained particular knowledge, skills and competences against criteria such as learning outcomes or standards of competence. Learning Assessment Specification is a subclass of Specification.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en"> A free text description of the learning assessment specification. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
+    <rdfs:label xml:lang="en">Learning Assessment Specification Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">more information</sh:name>
       <sh:description xml:lang="en"> An additional free text note about the learning assessment specification.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">alternative label</sh:name>
+      <sh:description xml:lang="en">The alternative name of the learning assessment specification.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1592,11 +1549,35 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">generalisation of</sh:name>
-      <sh:description xml:lang="en">A learning assessment specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
+      <sh:name xml:lang="en">is part of</sh:name>
+      <sh:description xml:lang="en">A learning assessment specification, which this learning assessment specification is part of.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">publisher</sh:name>
+      <sh:description xml:lang="en">The publisher of the learning assessment specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">specialisation of</sh:name>
+      <sh:description xml:lang="en">An assessment specification (e.g., a standard) of which this specification is a specialisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/specialisationOf"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A Learning  Assessment Specification is a specification of a process establishing the extent to which a learner has attained particular knowledge, skills and competences against criteria such as learning outcomes or standards of competence. Learning Assessment Specification is a subclass of Specification.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">grading scheme</sh:name>
@@ -1608,10 +1589,28 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the learning assessment. A concept indicating the type of the learning assessment.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:name xml:lang="en">generalisation of</sh:name>
+      <sh:description xml:lang="en">A learning assessment specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en"> The title of the learning assessment specification. One value per language is permitted.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">category</sh:name>
+      <sh:description xml:lang="en">The category of the learning assessment specification provided as a string.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1622,33 +1621,34 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">specialisation of</sh:name>
-      <sh:description xml:lang="en">An assessment specification (e.g., a standard) of which this specification is a specialisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/specialisationOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the learning assessment specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the learning assessment. A concept indicating the type of the learning assessment.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
     <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web resource containing additional documentation about the learning assessment specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the learning assessment specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">mode</sh:name>
+      <sh:description xml:lang="en">The mode of learning and or assessment (i.e., online, blended, presential, work based). It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
     </sh:property>
   </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/EmailAddressShape">
-    <rdfs:label xml:lang="en">Email Address Shape</rdfs:label>
-    <rdfs:comment xml:lang="en">An e-mail address.</rdfs:comment>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/MailboxShape">
+    <rdfs:label xml:lang="en">Mailbox Shape</rdfs:label>
+    <rdfs:comment xml:lang="en">A mailbox.</rdfs:comment>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
@@ -1658,80 +1658,28 @@
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/QualificationShape">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">maximum duration</sh:name>
-      <sh:description xml:lang="en">The maximum duration (in months) that a person may use to complete the learning opportunity for which this qualification is designed.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/maximumDuration"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web resource containing additional documentation about the qualification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:disjoint rdf:resource="http://purl.org/dc/terms/title"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:description xml:lang="en">The alternative name of the qualification. It must be disjoint with title (dc:title) of the Qualification.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the qualification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">has part</sh:name>
-      <sh:description xml:lang="en">A qualification can be composed of other qualification which when combined make up this qualification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">NQF level</sh:name>
-      <sh:description xml:lang="en">The qualification level as specified by a National Qualification Framework. It is recommended to use the QDR List of qualification frameworks.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/NQFLevel"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A specification of an assessment and validation process which is obtained when a competent authority determines that an individual has achieved learning outcomes to given standards. Qualification is a subclass of Learning Achievement Specification.</rdfs:comment>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">proven by</sh:name>
-      <sh:description xml:lang="en">Assessments a person can undergo to prove the acquisition of the learning outcomes.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/provenBy"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">learning outcome summary</sh:name>
-      <sh:description xml:lang="en">The full learning outcome summary of the qualification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcomeSummary"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">credit points</sh:name>
       <sh:description xml:lang="en">The credit points assigned to the qualification, following an educational credit system.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/CreditPoint"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/creditPoint"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">specialisation of</sh:name>
+      <sh:description xml:lang="en">A qualification (e.g., a standard) of which this qualification is a specialisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/specialisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en"> The title of the qualification. One value per language is permitted.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1742,10 +1690,49 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">entry requirement</sh:name>
+      <sh:description xml:lang="en">Specific entry requirement or prerequisite of individuals for which this qualification is designed to start this learning opportunity.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entryRequirement"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en"> A free text description of the qualification. One value per language is permitted.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">target group</sh:name>
       <sh:description xml:lang="en">A specific target group or category for which this qualification is designed. It should be provided using the EDC Controlled List of Target Groups.</sh:description>
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/targetGroup"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">qualification code</sh:name>
+      <sh:description xml:lang="en">An identifying code from a qualification-based reference semantic asset. This property is used to classify the qualification information with a qualification from a known qualification framework. (e.g., the link to the accredited NQF qualification).</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/qualificationCode"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">is part of</sh:name>
+      <sh:description xml:lang="en">A qualification, which this qualificationis part of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the qualification. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1764,41 +1751,33 @@
       <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">education level</sh:name>
-      <sh:description xml:lang="en">An associated level of education within a semantic framework describing education levels.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationLevel"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web resource containing additional documentation about the qualification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
     </sh:property>
+    <rdfs:comment xml:lang="en">A specification of an assessment and validation process which is obtained when a competent authority determines that an individual has achieved learning outcomes to given standards. Qualification is a subclass of Learning Achievement Specification.</rdfs:comment>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en"> An additional free text note about the qualification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+      <sh:name xml:lang="en">has part</sh:name>
+      <sh:description xml:lang="en">A qualification can be composed of other qualification which when combined make up this qualification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
     </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">mode</sh:name>
-      <sh:description xml:lang="en">The mode of learning, and or assessment. It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">education subject</sh:name>
-      <sh:description xml:lang="en">An associated field of education from another semantic framework than the ISCED classification.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationSubject"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">volume of learning</sh:name>
-      <sh:description xml:lang="en">The estimated number of hours the learner is expected to spend engaged in learning to earn the award. This would include the notional number of hours in class, in group work, in practicals, as well as hours engaged in self-motivated study.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/volumeOfLearning"/>
+      <sh:name xml:lang="en">learning outcome</sh:name>
+      <sh:description xml:lang="en">An individual (expected) learning outcome of the qualificationn.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOutcome"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcome"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1809,12 +1788,103 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">entry requirement</sh:name>
-      <sh:description xml:lang="en">Specific entry requirement or prerequisite of individuals for which this qualification is designed to start this learning opportunity.</sh:description>
+      <sh:name xml:lang="en">education subject</sh:name>
+      <sh:description xml:lang="en">An associated field of education from another semantic framework than the ISCED classification.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationSubject"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accreditation</sh:name>
+      <sh:description xml:lang="en">The associated accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditation"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">partial qualification</sh:name>
+      <sh:description xml:lang="en">Indicates whether a qualification is a full qualification or part of another qualification.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartialQualification"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">generalisation of</sh:name>
+      <sh:description xml:lang="en">A qualification (e.g., a standard) of which this qualification is a generalisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the qualification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">entitles To</sh:name>
+      <sh:description xml:lang="en">Rights (such as which the person may acquire as a result of acquiring the learning outcomes).</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitlesTo"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">thematic area</sh:name>
+      <sh:description xml:lang="en">The thematic area according to the ISCED-F 2013 Classification. It should be provided using the ISCEDF controlled vocabulary.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/ISCEDFCode"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the qualification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">proven by</sh:name>
+      <sh:description xml:lang="en">Assessments a person can undergo to prove the acquisition of the learning outcomes.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningAssessmentSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/provenBy"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en"> An additional free text note about the qualification.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entryRequirement"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">education level</sh:name>
+      <sh:description xml:lang="en">An associated level of education within a semantic framework describing education levels.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/educationLevel"/>
+    </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">influenced by</sh:name>
+      <sh:description xml:lang="en">Activities that a person can perform to acquire the expected learning outcomes.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/influencedBy"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">mode</sh:name>
+      <sh:description xml:lang="en">The mode of learning, and or assessment. It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1833,11 +1903,40 @@
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningSetting"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
+      <sh:disjoint rdf:resource="http://purl.org/dc/terms/title"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accreditation</sh:name>
-      <sh:description xml:lang="en">The associated accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditation"/>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:description xml:lang="en">The alternative name of the qualification. It must be disjoint with title (dc:title) of the Qualification.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Qualification Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">NQF level</sh:name>
+      <sh:description xml:lang="en">The qualification level as specified by a National Qualification Framework. It is recommended to use the QDR List of qualification frameworks.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/NQFLevel"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">maximum duration</sh:name>
+      <sh:description xml:lang="en">The maximum duration (in months) that a person may use to complete the learning opportunity for which this qualification is designed.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/maximumDuration"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the qualification was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1852,113 +1951,21 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">qualification code</sh:name>
-      <sh:description xml:lang="en">An identifying code from a qualification-based reference semantic asset. This property is used to classify the qualification information with a qualification from a known qualification framework. (e.g., the link to the accredited NQF qualification).</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/qualificationCode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en"> The title of the qualification. One value per language is permitted.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en"> A free text description of the qualification. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">specialisation of</sh:name>
-      <sh:description xml:lang="en">A qualification (e.g., a standard) of which this qualification is a specialisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/specialisationOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">learning outcome</sh:name>
-      <sh:description xml:lang="en">An individual (expected) learning outcome of the qualificationn.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningOutcome"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcome"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">entitles To</sh:name>
-      <sh:description xml:lang="en">Rights (such as which the person may acquire as a result of acquiring the learning outcomes).</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitlesTo"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the qualification was last modified.</sh:description>
+      <sh:name xml:lang="en">volume of learning</sh:name>
+      <sh:description xml:lang="en">The estimated number of hours the learner is expected to spend engaged in learning to earn the award. This would include the notional number of hours in class, in group work, in practicals, as well as hours engaged in self-motivated study.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/volumeOfLearning"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the qualification. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">partial qualification</sh:name>
-      <sh:description xml:lang="en">Indicates whether a qualification is a full qualification or part of another qualification.</sh:description>
+      <sh:name xml:lang="en">learning outcome summary</sh:name>
+      <sh:description xml:lang="en">The full learning outcome summary of the qualification.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartialQualification"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the qualification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Qualification Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">generalisation of</sh:name>
-      <sh:description xml:lang="en">A qualification (e.g., a standard) of which this qualification is a generalisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">thematic area</sh:name>
-      <sh:description xml:lang="en">The thematic area according to the ISCED-F 2013 Classification. It should be provided using the ISCEDF controlled vocabulary.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/ISCEDFCode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">is part of</sh:name>
-      <sh:description xml:lang="en">A qualification, which this qualificationis part of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/learningOutcomeSummary"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -1974,24 +1981,28 @@
       </sh:or>
       <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">influenced by</sh:name>
-      <sh:description xml:lang="en">Activities that a person can perform to acquire the expected learning outcomes.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/influencedBy"/>
-    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/MediaObjectShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the media object.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
     <rdfs:comment xml:lang="en">A media object.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">content size</sh:name>
-      <sh:description xml:lang="en">The content size of the media object.</sh:description>
+      <sh:name xml:lang="en">content</sh:name>
+      <sh:description xml:lang="en">The binary data of the media object.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentSize"/>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/content"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2004,6 +2015,21 @@
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentEncoding"/>
     </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <rdfs:label xml:lang="en">Media Object Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">attachment type</sh:name>
+      <sh:description xml:lang="en">The type of the attachment of the media object. It should be provided using a controlled list, with values: Transcript of Records, EMREX transcript, Letter of Nomination,  Diploma Supplement, Certificate of Training, Learning Agreement, Other.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/attachmentType"/>
+    </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -2015,38 +2041,12 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the media object.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">attachment type</sh:name>
-      <sh:description xml:lang="en">The type of the attachment of the media object. It should be provided using a controlled list, with values: Transcript of Records, EMREX transcript, Letter of Nomination,  Diploma Supplement, Certificate of Training, Learning Agreement, Other.</sh:description>
+      <sh:name xml:lang="en">content size</sh:name>
+      <sh:description xml:lang="en">The content size of the media object.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/attachmentType"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Media Object Shape</rdfs:label>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">content</sh:name>
-      <sh:description xml:lang="en">The binary data of the media object.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/content"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contentSize"/>
     </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
     <sh:property rdf:parseType="Resource">
@@ -2062,6 +2062,89 @@
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LearningActivitySpecificationShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">contact hours</sh:name>
+      <sh:description xml:lang="en">The contact hours.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactHour"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the learning activity specification was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en"> The title of the learning activity specification. One value per language is permitted.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the learning activity specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">is part of</sh:name>
+      <sh:description xml:lang="en">A learning activity specification, which this learning activity specification is part of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the learning activity specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <rdfs:comment xml:lang="en">The specification of a process which leads to the acquisition of knowledge, skills or responsibility and autonomy. Learning Activity Specification is a subclass of Specification.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">generalisation of</sh:name>
+      <sh:description xml:lang="en">A learning asctivity specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative identifier of the learning activity specification.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web resource containing additional documentation about the learning activity specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">publisher</sh:name>
@@ -2080,107 +2163,10 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">has part</sh:name>
-      <sh:description xml:lang="en">A learning activity specification can be composed of smaller learning specifications, which when combined make up this learning specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative label</sh:name>
-      <sh:description xml:lang="en">The alternative name of the learning activity specification.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">contact hours</sh:name>
-      <sh:description xml:lang="en">The contact hours.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactHour"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">category</sh:name>
-      <sh:description xml:lang="en">The category of the learning activity specification provided as a string.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">The specification of a process which leads to the acquisition of knowledge, skills or responsibility and autonomy. Learning Activity Specification is a subclass of Specification.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en"> A free text description of the learning activity specification. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web resource containing additional documentation about the learning activity specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the learning activity specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">language</sh:name>
-      <sh:description xml:lang="en">The language of instruction of the learning activity. It should be provided using the Language Named Authority List.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/language"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en"> The title of the learning activity specification. One value per language is permitted.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">is part of</sh:name>
-      <sh:description xml:lang="en">A learning activity specification, which this learning activity specification is part of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative identifier of the learning activity specification.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the learning activity specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en"> An additional free text note about the learning activity specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2191,6 +2177,15 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/volumeOfLearning"/>
     </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">mode</sh:name>
+      <sh:description xml:lang="en">The mode of learning and or assessment (i.e., online, blended, presential, work based.  It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
+    </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">influences</sh:name>
@@ -2208,16 +2203,27 @@
       </sh:or>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/influences"/>
     </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the learning activity specification was last modified.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:name xml:lang="en">alternative label</sh:name>
+      <sh:description xml:lang="en">The alternative name of the learning activity specification.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">category</sh:name>
+      <sh:description xml:lang="en">The category of the learning activity specification provided as a string.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">language</sh:name>
+      <sh:description xml:lang="en">The language of instruction of the learning activity. It should be provided using the Language Named Authority List.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/language"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2226,7 +2232,6 @@
       <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">specialisation of</sh:name>
@@ -2236,68 +2241,23 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">mode</sh:name>
-      <sh:description xml:lang="en">The mode of learning and or assessment (i.e., online, blended, presential, work based.  It should be provided using the EDC Controlled List of Modes Of Learning and Assessment.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/mode"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">generalisation of</sh:name>
-      <sh:description xml:lang="en">A learning asctivity specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
+      <sh:name xml:lang="en">has part</sh:name>
+      <sh:description xml:lang="en">A learning activity specification can be composed of smaller learning specifications, which when combined make up this learning specification.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningActivitySpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en"> An additional free text note about the learning activity specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Learning Activity Specification Shape</rdfs:label>
-  </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LocationShape">
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">spatial code</sh:name>
-      <sh:description xml:lang="en">A code identifying a spatial scope in which this physical location is located. It should be provided using the Administrative territorial unit Authority Table (ATU).</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/spatialCode"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
       >true</sh:uniqueLang>
       <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the location.</sh:description>
+      <sh:description xml:lang="en"> A free text description of the learning activity specification. One value per language is permitted.</sh:description>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
     </sh:property>
-    <rdfs:label xml:lang="en">Location Shape</rdfs:label>
-    <rdfs:comment xml:lang="en">An identifiable geographic place.</rdfs:comment>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">geographic name</sh:name>
-      <sh:description xml:lang="en">A proper noun applied to a spatial object. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/geographicName"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://purl.org/dc/terms/Location"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">geometry</sh:name>
-      <sh:description xml:lang="en">Associates the Location with the corresponding Geometry.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/locn#geometry"/>
-    </sh:property>
+    <rdfs:label xml:lang="en">Learning Activity Specification Shape</rdfs:label>
+  </sh:NodeShape>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LocationShape">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">address</sh:name>
@@ -2307,6 +2267,7 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
     </sh:property>
+    <rdfs:label xml:lang="en">Location Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier</sh:name>
@@ -2321,6 +2282,45 @@
       </sh:or>
       <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
+    <rdfs:comment xml:lang="en">An identifiable geographic place.</rdfs:comment>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:targetClass rdf:resource="http://purl.org/dc/terms/Location"/>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">spatial code</sh:name>
+      <sh:description xml:lang="en">A code identifying a spatial scope in which this physical location is located. It should be provided using the Administrative territorial unit Authority Table (ATU).</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/spatialCode"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">geographic name</sh:name>
+      <sh:description xml:lang="en">A proper noun applied to a spatial object. One value per language is permitted.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/geographicName"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the location.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">geometry</sh:name>
+      <sh:description xml:lang="en">Associates the Location with the corresponding Geometry.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/locn#geometry"/>
+    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/ConceptScheme">
     <rdfs:label xml:lang="en">Concept  Scheme Shape</rdfs:label>
@@ -2328,20 +2328,6 @@
     <sh:targetClass rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/LearningEntitlementSpecificationShape">
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the learning entitlement specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en"> An additional free text note about the learning entitlement specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -2355,12 +2341,53 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the learning entitlement specification was last modified.</sh:description>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The status of the learning entitlement specification. It should be provided using the EDC Controlled List of Entitlement Status.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitlementStatus"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
+    <rdfs:comment xml:lang="en">The specification of a right a person has access to, typically as a result of a learning achievement. It may take the form of the right to be a member of an organisation, to follow a certain learning opportunity specification, or to follow a certain career. Learning Entitletment Specifications is a subclass of Specification.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the learning entitlement specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">publisher</sh:name>
+      <sh:description xml:lang="en">The publisher of the learning entitlement specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">generalisation of</sh:name>
+      <sh:description xml:lang="en">A learning entitlement specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">valid within</sh:name>
+      <sh:description xml:lang="en">The jurisdiction for which the entitlement is valid (the region or country). It should be provided using Administrative territorial unit Authority Table (ATU).</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
@@ -2370,16 +2397,12 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
-    <rdfs:comment xml:lang="en">The specification of a right a person has access to, typically as a result of a learning achievement. It may take the form of the right to be a member of an organisation, to follow a certain learning opportunity specification, or to follow a certain career. Learning Entitletment Specifications is a subclass of Specification.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en"> A free text description of the learning entitlement specification. One value per language is permitted.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+      <sh:name xml:lang="en">limit national occupation</sh:name>
+      <sh:description xml:lang="en">An Occupation or Occupational Category. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitNationalOccupation"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2398,31 +2421,25 @@
       </sh:or>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitledBy"/>
     </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">has part</sh:name>
-      <sh:description xml:lang="en">Smaller entitlement specifications, which when combined make up this entitlement specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">valid within</sh:name>
-      <sh:description xml:lang="en">The jurisdiction for which the entitlement is valid (the region or country). It should be provided using Administrative territorial unit Authority Table (ATU).</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative label</sh:name>
-      <sh:description xml:lang="en">The alternative name of the learning entitlement specification.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
     <rdfs:label xml:lang="en">Learning Entitlement Specification Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">related occupation</sh:name>
+      <sh:description xml:lang="en">The ESCO Occupation or Occupational class which the individual may access through the entitlement. It should be provided using the ESCO Occupations.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitOccupation"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the learning entitlement. It should be provided using the EDC Controlled List of Entitlement Types.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier</sh:name>
@@ -2439,6 +2456,16 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en"> An additional free text note about the learning entitlement specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">specialisation of</sh:name>
       <sh:description xml:lang="en">An entitlement specification (e.g., a standard) of which this specification is a specialisation.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
@@ -2446,25 +2473,28 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The status of the learning entitlement specification. It should be provided using the EDC Controlled List of Entitlement Status.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/entitlementStatus"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en"> A free text description of the learning entitlement specification. One value per language is permitted.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the learning entitlement specification was last modified.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the learning entitlement. It should be provided using the EDC Controlled List of Entitlement Types.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">has part</sh:name>
+      <sh:description xml:lang="en">Smaller entitlement specifications, which when combined make up this entitlement specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/hasPart"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2473,6 +2503,15 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitOrganisation"/>
     </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">alternative label</sh:name>
+      <sh:description xml:lang="en">The alternative name of the learning entitlement specification.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">is part of</sh:name>
@@ -2480,38 +2519,6 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/isPartOf"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">related occupation</sh:name>
-      <sh:description xml:lang="en">The ESCO Occupation or Occupational class which the individual may access through the entitlement. It should be provided using the ESCO Occupations.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitOccupation"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">limit national occupation</sh:name>
-      <sh:description xml:lang="en">An Occupation or Occupational Category. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitNationalOccupation"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">publisher</sh:name>
-      <sh:description xml:lang="en">The publisher of the learning entitlement specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">status</sh:name>
@@ -2528,25 +2535,8 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">generalisation of</sh:name>
-      <sh:description xml:lang="en">A learning entitlement specification (e.g., a standard) of which this specification is a generalisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LearningEntitlementSpecification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/generalisationOf"/>
-    </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/AgentShape">
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the organisation.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -2556,70 +2546,15 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
     </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An identifier of the agent.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <rdfs:comment xml:lang="en">An entity that is able to carry out actions.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">group member of</sh:name>
-      <sh:description xml:lang="en">The group the agent is a member of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">contact information</sh:name>
-      <sh:description xml:lang="en">The contact information of the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the agent was last modified.</sh:description>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the organisation.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Agent Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:disjoint rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:description xml:lang="en">The alternative name of the agent. It must be disjoint with name (skos:prefLabel) of the Agent.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The location of the agent.</sh:description>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2636,6 +2571,71 @@
         </rdf:Description>
       </sh:or>
       <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+    </sh:property>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <rdfs:comment xml:lang="en">An entity that is able to carry out actions.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An identifier of the agent.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:disjoint rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:description xml:lang="en">The alternative name of the agent. It must be disjoint with name (skos:prefLabel) of the Agent.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Agent Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The location of the agent.</sh:description>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the agent was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">contact information</sh:name>
+      <sh:description xml:lang="en">The contact information of the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">group member of</sh:name>
+      <sh:description xml:lang="en">The group the agent is a member of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/CreditPointShape">
@@ -2680,13 +2680,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web resource containing additional documentation about the specification.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
       >true</sh:uniqueLang>
       <sh:name xml:lang="en">title</sh:name>
@@ -2695,6 +2688,73 @@
       >1</sh:minCount>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">alternative label</sh:name>
+      <sh:description xml:lang="en">The alternative name of the specification.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">category</sh:name>
+      <sh:description xml:lang="en">The category of the specification provided as a string.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">publisher</sh:name>
+      <sh:description xml:lang="en">The publisher of the specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en"> The type of the specification. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An alternative identifier of the specification.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the specification.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the specification.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -2714,80 +2774,20 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en"> The type of the specification. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative label</sh:name>
-      <sh:description xml:lang="en">The alternative name of the specification.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An alternative identifier of the specification.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
-    </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">publisher</sh:name>
-      <sh:description xml:lang="en">The publisher of the specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://purl.org/dc/terms/publisher"/>
-    </sh:property>
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">category</sh:name>
-      <sh:description xml:lang="en">The category of the specification provided as a string.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/category"/>
-    </sh:property>
     <rdfs:label xml:lang="en">Specification Shape</rdfs:label>
     <rdfs:comment xml:lang="en">A specification. The superclass of all learning specifications. This class carries properties common to all specifications, including Learning Achievement Specification, Learning Activity Specification, Learning Assessment Specification and Learning Entitlement Specification. It serves as an extension point that enables the definition of additional subclasses.</rdfs:comment>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Specification"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the specification.</sh:description>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web resource containing additional documentation about the specification.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the specification.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/AddressShape">
@@ -2835,30 +2835,25 @@
     >true</sh:closed>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/PriceDetailShape">
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/PriceDetail"/>
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/PriceDetail"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">fee amount</sh:name>
+      <sh:description xml:lang="en">The full (sticker) price of the learning opportunity.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Amount"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/amount"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">more information</sh:name>
       <sh:description xml:lang="en">An additional free text note about the price.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">The identifier of the price category, allocated by the organisation charging the fee.</sh:description>
-      <sh:or rdf:parseType="Collection">
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-        </rdf:Description>
-        <rdf:Description>
-          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-        </rdf:Description>
-      </sh:or>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
@@ -2873,12 +2868,17 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">fee amount</sh:name>
-      <sh:description xml:lang="en">The full (sticker) price of the learning opportunity.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Amount"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/amount"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">The identifier of the price category, allocated by the organisation charging the fee.</sh:description>
+      <sh:or rdf:parseType="Collection">
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+        </rdf:Description>
+        <rdf:Description>
+          <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+        </rdf:Description>
+      </sh:or>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
     <rdfs:comment xml:lang="en">The price details. The details about a price or price category.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
@@ -2998,9 +2998,6 @@
     >true</sh:closed>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/ContactPointShape">
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
     <rdfs:comment xml:lang="en">A contact point for an agent.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
@@ -3009,6 +3006,22 @@
       <sh:description xml:lang="en">An additional free text note about the contact point.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">address</sh:name>
+      <sh:description xml:lang="en">A postal address used for contacting the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the contact details.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:node>
@@ -3034,14 +3047,13 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactForm"/>
     </sh:property>
+    <rdfs:label xml:lang="en">Contact Point Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the contact details.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+      <sh:name xml:lang="en">phone</sh:name>
+      <sh:description xml:lang="en">A phone number used for contacting the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/phone"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:and rdf:parseType="Collection">
@@ -3055,31 +3067,39 @@
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">emailAddress</sh:name>
       <sh:description xml:lang="en">An e-mail address used for contacting the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/emailAddress"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Contact Point Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">address</sh:name>
-      <sh:description xml:lang="en">A postal address used for contacting the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">phone</sh:name>
-      <sh:description xml:lang="en">A phone number used for contacting the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/phone"/>
     </sh:property>
     <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
     >true</sh:closed>
-  </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/AccreditationShape">
     <sh:ignoredProperties rdf:parseType="Collection">
       <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     </sh:ignoredProperties>
+  </sh:NodeShape>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/AccreditationShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accredited for EQF level</sh:name>
+      <sh:description xml:lang="en">The European Qualification Framework level for which the accreditation is valid. It should be provided using the EQF controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitEQFLevel"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">status</sh:name>
+      <sh:description xml:lang="en">The publication status of the accreditation.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">publisher</sh:name>
@@ -3098,39 +3118,37 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">title</sh:name>
-      <sh:description xml:lang="en"> The title of the accreditation. One value per language is permitted.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+      <sh:name xml:lang="en">decision</sh:name>
+      <sh:description xml:lang="en">The Quality Decision issued by the Quality Assuring Authority. It should be provided using a controlled list.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/decision"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">expiry date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation expires or was expired.</sh:description>
+      <sh:name xml:lang="en">accredited for thematic area</sh:name>
+      <sh:description xml:lang="en">The field of education for which the accreditation is valid. It should be provided using the ISCED-F controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitField"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">review date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation has to be re-viewed.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/expiryDate"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/reviewDate"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accredited in jurisdiction</sh:name>
-      <sh:description xml:lang="en">The jurisdiction for which the accreditation is valid. It should be provided using the Administrative territorial unit Authority Table (ATU) controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">qualification accredited</sh:name>
-      <sh:description xml:lang="en">The qualification that was accredited.</sh:description>
+      <sh:name xml:lang="en">report</sh:name>
+      <sh:description xml:lang="en">A publicly accessible report of the quality assurance decision.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitQualification"/>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/report"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -3143,6 +3161,57 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/accreditingAgent"/>
     </sh:property>
+    <rdfs:label xml:lang="en">Accreditation Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">title</sh:name>
+      <sh:description xml:lang="en"> The title of the accreditation. One value per language is permitted.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">The quality assurance or licensing of an organisation or a qualification. An accreditation instance can be used to specify information about: (1) the quality assurance and/or licensing of an organisation, (2) the quality assurance and/or licensing of an organisation with respect to a specific qualification.</rdfs:comment>
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">expiry date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation expires or was expired.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/expiryDate"/>
+    </sh:property>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">accredited in jurisdiction</sh:name>
+      <sh:description xml:lang="en">The jurisdiction for which the accreditation is valid. It should be provided using the Administrative territorial unit Authority Table (ATU) controlled vocabulary.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A web resource containing additional documentation describing the Accreditation Procedures and Standards.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -3151,6 +3220,24 @@
       <sh:description xml:lang="en">A free text description of the accreditation. One value per language is permitted.</sh:description>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation was last updated since it was published.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">qualification accredited</sh:name>
+      <sh:description xml:lang="en">The qualification that was accredited.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Qualification"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitQualification"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -3167,75 +3254,6 @@
       <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">landing page</sh:name>
-      <sh:description xml:lang="en">The landing page of the accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/landingPage"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Accreditation Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">status</sh:name>
-      <sh:description xml:lang="en">The publication status of the accreditation.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/status"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A web resource containing additional documentation describing the Accreditation Procedures and Standards.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">The quality assurance or licensing of an organisation or a qualification. An accreditation instance can be used to specify information about: (1) the quality assurance and/or licensing of an organisation, (2) the quality assurance and/or licensing of an organisation with respect to a specific qualification.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">report</sh:name>
-      <sh:description xml:lang="en">A publicly accessible report of the quality assurance decision.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/report"/>
-    </sh:property>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accredited for thematic area</sh:name>
-      <sh:description xml:lang="en">The field of education for which the accreditation is valid. It should be provided using the ISCED-F controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitField"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">validation  date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation became valid.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/valid"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the accreditation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">accreditation date issued</sh:name>
       <sh:description xml:lang="en">The date when the accreditation was formally approved/issued.</sh:description>
@@ -3244,7 +3262,6 @@
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Accreditation"/>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">organisation</sh:name>
@@ -3255,29 +3272,12 @@
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/organisation"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
+      <sh:node rdf:resource="http://data.europa.eu/snb/model/ap/loq-constraints/URLRegexRestriction"/>
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">decision</sh:name>
-      <sh:description xml:lang="en">The Quality Decision issued by the Quality Assuring Authority. It should be provided using a controlled list.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/decision"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">accredited for EQF level</sh:name>
-      <sh:description xml:lang="en">The European Qualification Framework level for which the accreditation is valid. It should be provided using the EQF controlled vocabulary.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitEQFLevel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation was last updated since it was published.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+      <sh:name xml:lang="en">landing page</sh:name>
+      <sh:description xml:lang="en">The landing page of the accreditation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/landingPage"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -3292,15 +3292,30 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">review date</sh:name>
-      <sh:description xml:lang="en">The date when the accreditation has to be re-viewed.</sh:description>
+      <sh:name xml:lang="en">validation  date</sh:name>
+      <sh:description xml:lang="en">The date when the accreditation became valid.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/reviewDate"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/valid"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/loq-constraints/GradingSchemeShape">
+    <sh:ignoredProperties rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    </sh:ignoredProperties>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">other documents</sh:name>
+      <sh:description xml:lang="en">A public web document containing additional documentation about the grading scheme.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A set of criteria that measures varying levels of achievement.</rdfs:comment>
+    <rdfs:label xml:lang="en">Grading Scheme Shape</rdfs:label>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/GradingScheme"/>
+    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >true</sh:closed>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -3312,27 +3327,6 @@
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/title"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">A set of criteria that measures varying levels of achievement.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">description</sh:name>
-      <sh:description xml:lang="en">A free text description of the grading scheme.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">other documents</sh:name>
-      <sh:description xml:lang="en">A public web document containing additional documentation about the grading scheme.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/supplementaryDocument"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Grading Scheme Shape</rdfs:label>
-    <sh:ignoredProperties rdf:parseType="Collection">
-      <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    </sh:ignoredProperties>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier</sh:name>
@@ -3347,8 +3341,14 @@
       </sh:or>
       <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/GradingScheme"/>
-    <sh:closed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-    >true</sh:closed>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">description</sh:name>
+      <sh:description xml:lang="en">A free text description of the grading scheme.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
+    </sh:property>
   </sh:NodeShape>
 </rdf:RDF>

--- a/rdf/ap/pid/PID-constraints.ttl
+++ b/rdf/ap/pid/PID-constraints.ttl
@@ -813,7 +813,7 @@ sh:property[
   ];
   sh:property [
     sh:path elm:emailAddress;
-    sh:class elm:EmailAddress;
+    sh:class elm:Mailbox;
     sh:description "An e-mail address used for contacting the agent."@en;
     sh:name "emailAddress"@en;
     sh:severity sh:Violation;
@@ -993,13 +993,13 @@ sh:property[
 .
 
 #-------------------------------------------------------------------------
-#--------------- EmailAddress class and property  shapes ----------------------
+#--------------- Mailbox class and property  shapes ----------------------
 #-------------------------------------------------------------------------
-:EmailAddressShape
+:MailboxShape
   a sh:NodeShape;
-  sh:targetClass elm:EmailAddress;
-  rdfs:comment "An e-mail address."@en;
-  rdfs:label "Email Address Shape"@en;
+  sh:targetClass elm:Mailbox;
+  rdfs:comment "A mailbox."@en;
+  rdfs:label "Mailbox Shape"@en;
   .
 
 #-------------------------------------------------------------------------

--- a/rdf/ap/pid/documentation/PID-constraints.html
+++ b/rdf/ap/pid/documentation/PID-constraints.html
@@ -239,12 +239,12 @@
             <li><a href="#:ConceptScheme">Concept  Scheme Shape</a></li>
             <li><a href="#:ConceptShape">Concept Shape</a></li>
             <li><a href="#:ContactPointShape">Contact Point Shape</a></li>
-            <li><a href="#:EmailAddressShape">Email Address Shape</a></li>
             <li><a href="#:GeometryShape">Geometry Shape</a></li>
             <li><a href="#:GroupShape">Group Shape</a></li>
             <li><a href="#:IdentifierShape">Identifier Shape</a></li>
             <li><a href="#:LegalIdentifierShape">Legal Identifier Shape</a></li>
             <li><a href="#:LocationShape">Location Shape</a></li>
+            <li><a href="#:MailboxShape">Mailbox Shape</a></li>
             <li><a href="#:MediaObjectShape">Media Object Shape</a></li>
             <li><a href="#:NoteShape">Note Shape</a></li>
             <li><a href="#:OrganisationShape">Organisation Shape</a></li>
@@ -583,7 +583,7 @@
                 <tr>
                     <td>emailAddress</td>
                     <td><code><a href="http://data.europa.eu/snb/model/elm/emailAddress">elm:emailAddress</a></code></td>
-                    <td><code><a href="#:EmailAddressShape">Email Address Shape</a></code><br></td>
+                    <td><code><a href="#:MailboxShape">Mailbox Shape</a></code><br></td>
                     <td>
                         <div style="width:30px">0..*</div>
                     </td>
@@ -609,18 +609,6 @@
                 </tr>
                 </tbody>
             </table>
-        </section>
-    </div>
-</div><br><div class="row mt-3">
-    <div class="col">
-        <section id=":EmailAddressShape">
-            <div class="sp_section_title_table_wrapper">
-                <h2 class="sp_section_title_table">Email Address Shape</h2>
-            </div>
-            <p><em>An e-mail address.</em></p>
-            <ul class="sp_list_description_properties">
-                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/EmailAddress">elm:EmailAddress</a></li>
-            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">
@@ -1022,6 +1010,18 @@
                 </tr>
                 </tbody>
             </table>
+        </section>
+    </div>
+</div><br><div class="row mt-3">
+    <div class="col">
+        <section id=":MailboxShape">
+            <div class="sp_section_title_table_wrapper">
+                <h2 class="sp_section_title_table">Mailbox Shape</h2>
+            </div>
+            <p><em>A mailbox.</em></p>
+            <ul class="sp_list_description_properties">
+                <li>Applies to: <a href="http://data.europa.eu/snb/model/elm/Mailbox">elm:Mailbox</a></li>
+            </ul>
         </section>
     </div>
 </div><br><div class="row mt-3">

--- a/rdf/ap/pid/rdf-xml/PID-constraints.rdf
+++ b/rdf/ap/pid/rdf-xml/PID-constraints.rdf
@@ -65,26 +65,30 @@
     <sh:targetClass rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/PersonShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">member of</sh:name>
+      <sh:description xml:lang="en">The organisation of which the person is a member.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#memberOf"/>
+    </sh:property>
     <rdfs:label xml:lang="en">Person Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">gender</sh:name>
-      <sh:description xml:lang="en">The gender of the person. It should be provided using the Human Sex Named Authority List.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/gender"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">family name</sh:name>
-      <sh:description xml:lang="en">The family name of the person.</sh:description>
+      <sh:name xml:lang="en">full name</sh:name>
+      <sh:description xml:lang="en">The complete name of the person as one string.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/familyName"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/fullName"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">A human being. Person is a subclass of Agent.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">identifier</sh:name>
+      <sh:description xml:lang="en">An identifier of the person.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">national ID number</sh:name>
@@ -96,19 +100,36 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">given name</sh:name>
-      <sh:description xml:lang="en">The given name of the person.</sh:description>
+      <sh:name xml:lang="en">family name</sh:name>
+      <sh:description xml:lang="en">The family name of the person.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/givenName"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/familyName"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier</sh:name>
-      <sh:description xml:lang="en">An identifier of the person.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
+      <sh:name xml:lang="en">contact information</sh:name>
+      <sh:description xml:lang="en">The contact information of the person.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
+    </sh:property>
+    <rdfs:comment xml:lang="en">A human being. Person is a subclass of Agent.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">birth name</sh:name>
+      <sh:description xml:lang="en">The name of the person at birth. Birth names tend to be persistent and for this reason they are recorded by some public sector information systems. There is no granularity for birth name - the full name should be recorded in a single field.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/person#birthName"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">gender</sh:name>
+      <sh:description xml:lang="en">The gender of the person. It should be provided using the Human Sex Named Authority List.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/gender"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -128,20 +149,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">birth name</sh:name>
-      <sh:description xml:lang="en">The name of the person at birth. Birth names tend to be persistent and for this reason they are recorded by some public sector information systems. There is no granularity for birth name - the full name should be recorded in a single field.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/person#birthName"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">group member of</sh:name>
-      <sh:description xml:lang="en">The group the person is a member of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">patronymic name</sh:name>
       <sh:description xml:lang="en">Patronymic names are important in some countries. Iceland does not have a concept of 'family name' in the way that many other European countries do, for example, Erik Magnusson and Erika Magnusdottir are siblings, both offspring of Mangnus, irrespective of his patronymic name. In Bulgaria and Russia, patronymic names are in everyday usage, for example, the Sergeyevich in 'Mikhail Sergeyevich Gorbachev.</sh:description>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
@@ -158,13 +165,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">contact information</sh:name>
-      <sh:description xml:lang="en">The contact information of the person.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">date of birth</sh:name>
       <sh:description xml:lang="en">The date of birth of the person.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
@@ -174,19 +174,19 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">full name</sh:name>
-      <sh:description xml:lang="en">The complete name of the person as one string.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/fullName"/>
+      <sh:name xml:lang="en">group member of</sh:name>
+      <sh:description xml:lang="en">The group the person is a member of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">member of</sh:name>
-      <sh:description xml:lang="en">The organisation of which the person is a member.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#memberOf"/>
+      <sh:name xml:lang="en">given name</sh:name>
+      <sh:description xml:lang="en">The given name of the person.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/givenName"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -201,6 +201,7 @@
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/LocationShape">
     <rdfs:label xml:lang="en">Location Shape</rdfs:label>
+    <rdfs:comment xml:lang="en">An identifiable geographic place.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -209,14 +210,6 @@
       <sh:description xml:lang="en">A free text description of the location.</sh:description>
       <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/description"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">An identifiable geographic place.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">spatial code</sh:name>
-      <sh:description xml:lang="en">A code identifying a spatial scope in which this physical location is located. It should be provided using the Administrative territorial unit Authority Table (ATU).</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/spatialCode"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -245,6 +238,14 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
     </sh:property>
+    <sh:targetClass rdf:resource="http://purl.org/dc/terms/Location"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">spatial code</sh:name>
+      <sh:description xml:lang="en">A code identifying a spatial scope in which this physical location is located. It should be provided using the Administrative territorial unit Authority Table (ATU).</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/spatialCode"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">identifier</sh:name>
@@ -252,7 +253,6 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
       <sh:path rdf:resource="http://www.w3.org/ns/adms#identifier"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://purl.org/dc/terms/Location"/>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/ConceptShape">
     <sh:property rdf:parseType="Resource">
@@ -324,7 +324,7 @@
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">emailAddress</sh:name>
       <sh:description xml:lang="en">An e-mail address used for contacting the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/emailAddress"/>
     </sh:property>
     <rdfs:comment xml:lang="en">A contact point for an agent.</rdfs:comment>
@@ -346,6 +346,13 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">address</sh:name>
+      <sh:description xml:lang="en">A postal address used for contacting the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">contact form</sh:name>
       <sh:description xml:lang="en">A contact form used for contacting the agent.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
@@ -358,22 +365,121 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
     </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">address</sh:name>
-      <sh:description xml:lang="en">A postal address used for contacting the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Address"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/address"/>
-    </sh:property>
     <rdfs:label xml:lang="en">Contact Point Shape</rdfs:label>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/OrganisationShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">registration</sh:name>
+      <sh:description xml:lang="en">The legal identifier of an organisation. The identifier given to a registered organisation by the authority with which it is registered. The legal status of a registered organisation is conferred on it by an authority within a given jurisdiction. The Legal Identifier is therefore a fundamental relationship between an organisation and the authority with which it is registered.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/regorg#registration"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">last modification date</sh:name>
+      <sh:description xml:lang="en">The date when the organisation was last modified.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">logo</sh:name>
+      <sh:description xml:lang="en">The logo of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/logo"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">homepage</sh:name>
+      <sh:description xml:lang="en">The homepage of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
+      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">contact information</sh:name>
+      <sh:description xml:lang="en">The contact information of an organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">VAT number</sh:name>
       <sh:description xml:lang="en">The Value-Added Tax ID.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/vatIdentifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">tax/fiscal identifier</sh:name>
+      <sh:description xml:lang="en">Fiscal ID of the organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/taxIdentifier"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">group member of</sh:name>
+      <sh:description xml:lang="en">The group the organisation  is a member of.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the organisation.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">child organisation</sh:name>
+      <sh:description xml:lang="en">A smaller organisation of which forms part of this organisation, e.g., a department within a larger organisation.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#hasSubOrganization"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">parent organisation</sh:name>
+      <sh:description xml:lang="en">Indicates a larger organisation of which this organisation is a part of, e.g., the organisation within which a department operates.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/org#subOrganizationOf"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:description xml:lang="en">The alternative name of the organisation.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Organisation Shape</rdfs:label>
+    <rdfs:comment xml:lang="en">A legal person / registered organisation. Organisation is a subclass of Agent.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">legal name</sh:name>
+      <sh:description xml:lang="en">The legal name of the organisation.</sh:description>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/regorg#legalName"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -393,118 +499,12 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">child organisation</sh:name>
-      <sh:description xml:lang="en">A smaller organisation of which forms part of this organisation, e.g., a department within a larger organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#hasSubOrganization"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">last modification date</sh:name>
-      <sh:description xml:lang="en">The date when the organisation was last modified.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/modified"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">tax/fiscal identifier</sh:name>
-      <sh:description xml:lang="en">Fiscal ID of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/taxIdentifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">contact information</sh:name>
-      <sh:description xml:lang="en">The contact information of an organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">homepage</sh:name>
-      <sh:description xml:lang="en">The homepage of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
-      <sh:path rdf:resource="http://xmlns.com/foaf/0.1/homepage"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">parent organisation</sh:name>
-      <sh:description xml:lang="en">Indicates a larger organisation of which this organisation is a part of, e.g., the organisation within which a department operates.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Organisation"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/org#subOrganizationOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">eIDAS identifier</sh:name>
       <sh:description xml:lang="en">The official identification number of the organisation, as awarded by the relevant national authority.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/eidasLegalIdentifier"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">registration</sh:name>
-      <sh:description xml:lang="en">The legal identifier of an organisation. The identifier given to a registered organisation by the authority with which it is registered. The legal status of a registered organisation is conferred on it by an authority within a given jurisdiction. The Legal Identifier is therefore a fundamental relationship between an organisation and the authority with which it is registered.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/regorg#registration"/>
-    </sh:property>
-    <rdfs:label xml:lang="en">Organisation Shape</rdfs:label>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:description xml:lang="en">The alternative name of the organisation.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A legal person / registered organisation. Organisation is a subclass of Agent.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">legal name</sh:name>
-      <sh:description xml:lang="en">The legal name of the organisation.</sh:description>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/regorg#legalName"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the organisation.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">group member of</sh:name>
-      <sh:description xml:lang="en">The group the organisation  is a member of.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/groupMemberOf"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">logo</sh:name>
-      <sh:description xml:lang="en">The logo of the organisation.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/MediaObject"/>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/logo"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/MediaObjectShape">
@@ -649,6 +649,11 @@
     <rdfs:comment xml:lang="en">A phone.</rdfs:comment>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Phone"/>
   </sh:NodeShape>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/MailboxShape">
+    <rdfs:label xml:lang="en">Mailbox Shape</rdfs:label>
+    <rdfs:comment xml:lang="en">A mailbox.</rdfs:comment>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
+  </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/IdentifierShape">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -663,14 +668,12 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">scheme agency name</sh:name>
-      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:name xml:lang="en">scheme name</sh:name>
+      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -690,12 +693,12 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme name</sh:name>
-      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
+      <sh:name xml:lang="en">date issued</sh:name>
+      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -706,21 +709,29 @@
       <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
       <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
     </sh:property>
+    <rdfs:comment xml:lang="en">A character string used to identify a resource. An identifier is a character string used to uniquely identify one instance of an object within an identification scheme that is managed by an agency. The Identifier class is a critical aspect of the ELM. It is used to identify persons and organisations. In these cases, and more, the identifier itself will be some sort of alpha-numeric string but that string only has meaning if it is contextualised.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">date issued</sh:name>
-      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">scheme agency name</sh:name>
+      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
     </sh:property>
-    <rdfs:comment xml:lang="en">A character string used to identify a resource. An identifier is a character string used to uniquely identify one instance of an object within an identification scheme that is managed by an agency. The Identifier class is a critical aspect of the ELM. It is used to identify persons and organisations. In these cases, and more, the identifier itself will be some sort of alpha-numeric string but that string only has meaning if it is contextualised.</rdfs:comment>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Identifier"/>
     <rdfs:label xml:lang="en">Identifier Shape</rdfs:label>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/GroupShape">
-    <rdfs:label xml:lang="en">Group Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the group.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
@@ -734,21 +745,6 @@
       <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:minCount>
     </sh:property>
-    <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The location of the group.</sh:description>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
-    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">contact information</sh:name>
@@ -756,7 +752,7 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/contactPoint"/>
     </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+    <rdfs:label xml:lang="en">Group Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">has member</sh:name>
@@ -764,6 +760,7 @@
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
       <sh:path rdf:resource="http://xmlns.com/foaf/0.1/member"/>
     </sh:property>
+    <rdfs:comment xml:lang="en">An entity that represents collection of Agents.</rdfs:comment>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:description xml:lang="en">The alternative name of the group.</sh:description>
@@ -773,10 +770,18 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the group.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The location of the group.</sh:description>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:description xml:lang="en">The type of the group. It should be provided using a controlled vocabulary.</sh:description>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     </sh:property>
   </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/WebResourceShape">
@@ -813,68 +818,17 @@
     <rdfs:comment xml:lang="en">A public web resource.</rdfs:comment>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/WebResource"/>
   </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/EmailAddressShape">
-    <rdfs:label xml:lang="en">Email Address Shape</rdfs:label>
-    <rdfs:comment xml:lang="en">An e-mail address.</rdfs:comment>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
-  </sh:NodeShape>
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/LegalIdentifierShape">
-    <rdfs:label xml:lang="en">Legal Identifier Shape</rdfs:label>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">date issued</sh:name>
-      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
+      <sh:name xml:lang="en">identifier content</sh:name>
+      <sh:description xml:lang="en">Content string which is the identifier.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
-    </sh:property>
-    <rdfs:comment xml:lang="en">A legal identifier. A legal identifier is a formally issued identifier by a given authority within a given jurisdiction. The identifier has a spatial context. Legal Identifier is a subclass of Identifier.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">scheme agency name</sh:name>
-      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme version</sh:name>
-      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
+      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:minCount>
       <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme name</sh:name>
-      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
-    </sh:property>
-    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">scheme agency</sh:name>
-      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">type</sh:name>
-      <sh:description xml:lang="en">The type of the identifier.</sh:description>
-      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -889,18 +843,90 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">identifier content</sh:name>
-      <sh:description xml:lang="en">Content string which is the identifier.</sh:description>
+      <sh:name xml:lang="en">date issued</sh:name>
+      <sh:description xml:lang="en">The date on which the identifier was issued.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/issued"/>
+    </sh:property>
+    <rdfs:label xml:lang="en">Legal Identifier Shape</rdfs:label>
+    <rdfs:comment xml:lang="en">A legal identifier. A legal identifier is a formally issued identifier by a given authority within a given jurisdiction. The identifier has a spatial context. Legal Identifier is a subclass of Identifier.</rdfs:comment>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme name</sh:name>
+      <sh:description xml:lang="en">The name of the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeName"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme version</sh:name>
+      <sh:description xml:lang="en">Identification of the version of the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/schemeVersion"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">scheme agency name</sh:name>
+      <sh:description xml:lang="en">The name of the agent that manages the identifier scheme.</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/ns/adms#schemeAgency"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">type</sh:name>
+      <sh:description xml:lang="en">The type of the identifier.</sh:description>
+      <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/type"/>
+    </sh:property>
+    <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/LegalIdentifier"/>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">scheme agency</sh:name>
+      <sh:description xml:lang="en">Identification of the agent that manages the identifier scheme. The agent that issued the identifier. (e.g., a URI).</sh:description>
+      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
+      >1</sh:maxCount>
+      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
+      <sh:path rdf:resource="http://purl.org/dc/terms/creator"/>
+    </sh:property>
+  </sh:NodeShape>
+  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/AgentShape">
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:name xml:lang="en">more information</sh:name>
+      <sh:description xml:lang="en">An additional free text note about the agent.</sh:description>
+      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+    </sh:property>
+    <sh:property rdf:parseType="Resource">
+      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
+      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+      >true</sh:uniqueLang>
+      <sh:name xml:lang="en">preferred name</sh:name>
+      <sh:description xml:lang="en">The preferred name of the agent.</sh:description>
       <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:maxCount>
       <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
       >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#notation"/>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
     </sh:property>
-  </sh:NodeShape>
-  <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/pid-constraints/AgentShape">
     <rdfs:label xml:lang="en">Agent Shape</rdfs:label>
+    <sh:property rdf:parseType="Resource">
+      <sh:name xml:lang="en">location</sh:name>
+      <sh:description xml:lang="en">The location of the agent.</sh:description>
+      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
+      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
+    </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">contact information</sh:name>
@@ -919,19 +945,6 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">alternative name</sh:name>
-      <sh:description xml:lang="en">The alternative name of the agent.</sh:description>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:name xml:lang="en">location</sh:name>
-      <sh:description xml:lang="en">The location of the agent.</sh:description>
-      <sh:class rdf:resource="http://purl.org/dc/terms/Location"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/location"/>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:name xml:lang="en">group member of</sh:name>
       <sh:description xml:lang="en">The group the agent is a member of.</sh:description>
       <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Group"/>
@@ -939,10 +952,10 @@
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:name xml:lang="en">more information</sh:name>
-      <sh:description xml:lang="en">An additional free text note about the agent.</sh:description>
-      <sh:class rdf:resource="http://data.europa.eu/snb/model/elm/Note"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/additionalNote"/>
+      <sh:name xml:lang="en">alternative name</sh:name>
+      <sh:description xml:lang="en">The alternative name of the agent.</sh:description>
+      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
+      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#altLabel"/>
     </sh:property>
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
@@ -953,18 +966,5 @@
     </sh:property>
     <sh:targetClass rdf:resource="http://data.europa.eu/snb/model/elm/Agent"/>
     <rdfs:comment xml:lang="en">An entity that is able to carry out actions.</rdfs:comment>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:uniqueLang rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
-      >true</sh:uniqueLang>
-      <sh:name xml:lang="en">preferred name</sh:name>
-      <sh:description xml:lang="en">The preferred name of the agent.</sh:description>
-      <sh:maxCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:maxCount>
-      <sh:minCount rdf:datatype="http://www.w3.org/2001/XMLSchema#integer"
-      >1</sh:minCount>
-      <sh:datatype rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"/>
-      <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#prefLabel"/>
-    </sh:property>
   </sh:NodeShape>
 </rdf:RDF>

--- a/rdf/ontology/ELM.ttl
+++ b/rdf/ontology/ELM.ttl
@@ -357,12 +357,12 @@ elm:LegalIdentifier
 
 # -- Location ->dc:Location
 
-elm:EmailAddress
+elm:Mailbox
   a rdfs:Class;
   a owl:Class;
-  dc:identifier "elm:EmailAddress";
-  rdfs:comment "An e-mail address."@en;
-  rdfs:label "Email Address"@en;
+  dc:identifier "elm:Mailbox";
+  rdfs:comment "A mailbox."@en;
+  rdfs:label "Mailbox"@en;
   rdfs:isDefinedBy <http://data.europa.eu/snb/model/elm>;
 .
 
@@ -932,7 +932,7 @@ elm:emailAddress
   rdfs:label "emailAddress"@en;
 	rdfs:isDefinedBy <http://data.europa.eu/snb/model/elm>;
   rdfs:domain elm:ContactPoint;
-  rdfs:range elm:EmailAddress;
+  rdfs:range elm:Mailbox;
   .
 
 elm:contactForm
@@ -1811,7 +1811,7 @@ elm:spatialCode
   rdfs:range skos:Concept;
   .
 
-#----------- EmailAddress Class properties ---------------
+#----------- Mailbox Class properties ---------------
 
 # ---------  Media Object properties ----------
 

--- a/rdf/ontology/documentation/elm.html
+++ b/rdf/ontology/documentation/elm.html
@@ -6,7 +6,7 @@
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jun 07 16:24:55 CEST 2023", "version":"3.1.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Fri Jun 09 17:15:56 CEST 2023", "version":"3.1.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -141,10 +141,6 @@ This ontology has the following classes and properties.</span>
          title="http://data.europa.eu/snb/model/elm/DisplayParameter">Display Parameter</a>
    </li>
    <li>
-      <a href="#/EmailAddress"
-         title="http://data.europa.eu/snb/model/elm/EmailAddress">Email Address</a>
-   </li>
-   <li>
       <a href="#/EuropeanDigitalCredential"
          title="http://data.europa.eu/snb/model/elm/EuropeanDigitalCredential">European Digital Credential</a>
    </li>
@@ -215,6 +211,9 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#/LegalIdentifier"
          title="http://data.europa.eu/snb/model/elm/LegalIdentifier">Legal Identifier</a>
+   </li>
+   <li>
+      <a href="#/Mailbox" title="http://data.europa.eu/snb/model/elm/Mailbox">Mailbox</a>
    </li>
    <li>
       <a href="#/MediaObject" title="http://data.europa.eu/snb/model/elm/MediaObject">Media Object</a>
@@ -908,10 +907,6 @@ This section provides details for each class and property defined by Europass Le
             title="http://data.europa.eu/snb/model/elm/DisplayParameter">Display Parameter</a>
       </li>
       <li>
-         <a href="#/EmailAddress"
-            title="http://data.europa.eu/snb/model/elm/EmailAddress">Email Address</a>
-      </li>
-      <li>
          <a href="#/EuropeanDigitalCredential"
             title="http://data.europa.eu/snb/model/elm/EuropeanDigitalCredential">European Digital Credential</a>
       </li>
@@ -982,6 +977,9 @@ This section provides details for each class and property defined by Europass Le
       <li>
          <a href="#/LegalIdentifier"
             title="http://data.europa.eu/snb/model/elm/LegalIdentifier">Legal Identifier</a>
+      </li>
+      <li>
+         <a href="#/Mailbox" title="http://data.europa.eu/snb/model/elm/Mailbox">Mailbox</a>
       </li>
       <li>
          <a href="#/MediaObject" title="http://data.europa.eu/snb/model/elm/MediaObject">Media Object</a>
@@ -1420,30 +1418,6 @@ This section provides details for each class and property defined by Europass Le
          </dd>
       </dl>
    </div>
-   <div class="entity" id="/EmailAddress">
-      <h3>Email Address<sup class="type-c" title="class">c</sup>
-         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
-         </span>
-      </h3>
-      <p>
-         <strong>IRI:</strong> http://data.europa.eu/snb/model/elm/EmailAddress</p>
-      <div class="comment">
-         <span class="markdown">An e-mail address.</span>
-      </div>
-      <dl class="definedBy">
-         <dt>Is defined by</dt>
-         <dd>
-            <a href="http://data.europa.eu/snb/model/elm">http://data.europa.eu/snb/model/elm</a>
-         </dd>
-      </dl>
-      <dl class="description">
-         <dt>is in range of</dt>
-         <dd>
-            <a href="#/emailAddress" title="http://data.europa.eu/snb/model/elm/emailAddress">emailAddress</a>
-            <sup class="type-op" title="object property">op</sup>
-         </dd>
-      </dl>
-   </div>
    <div class="entity" id="/EuropeanDigitalCredential">
       <h3>European Digital Credential<sup class="type-c" title="class">c</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
@@ -1642,7 +1616,6 @@ This section provides details for each class and property defined by Europass Le
             <a href="http://www.w3.org/ns/adms#Identifier"
                target="_blank"
                title="http://www.w3.org/ns/adms#Identifier">identifier</a>
-            <sup class="type-c" title="class">c</sup>
          </dd>
          <dt>has sub-classes</dt>
          <dd>
@@ -2132,6 +2105,30 @@ This section provides details for each class and property defined by Europass Le
                title="http://data.europa.eu/snb/model/elm/vatIdentifier">VAT number</a>
             <sup class="type-op" title="object property">op</sup>, <a href="#/eidasLegalIdentifier"
                title="http://data.europa.eu/snb/model/elm/eidasLegalIdentifier">eIDAS identifier</a>
+            <sup class="type-op" title="object property">op</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="/Mailbox">
+      <h3>Mailbox<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> http://data.europa.eu/snb/model/elm/Mailbox</p>
+      <div class="comment">
+         <span class="markdown">A mailbox.</span>
+      </div>
+      <dl class="definedBy">
+         <dt>Is defined by</dt>
+         <dd>
+            <a href="http://data.europa.eu/snb/model/elm">http://data.europa.eu/snb/model/elm</a>
+         </dd>
+      </dl>
+      <dl class="description">
+         <dt>is in range of</dt>
+         <dd>
+            <a href="#/emailAddress" title="http://data.europa.eu/snb/model/elm/emailAddress">emailAddress</a>
             <sup class="type-op" title="object property">op</sup>
          </dd>
       </dl>
@@ -4197,8 +4194,7 @@ This section provides details for each class and property defined by Europass Le
             </dd>
             <dt>has range</dt>
             <dd>
-               <a href="#/EmailAddress"
-                  title="http://data.europa.eu/snb/model/elm/EmailAddress">Email Address</a>
+               <a href="#/Mailbox" title="http://data.europa.eu/snb/model/elm/Mailbox">Mailbox</a>
                <sup class="type-c" title="class">c</sup>
             </dd>
          </dl>

--- a/rdf/ontology/rdf-xml/ELM.rdf
+++ b/rdf/ontology/rdf-xml/ELM.rdf
@@ -167,6 +167,13 @@
     <dc:identifier>elm:AwardingProcess</dc:identifier>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
   </owl:Class>
+  <owl:Class rdf:about="http://data.europa.eu/snb/model/elm/Mailbox">
+    <rdfs:isDefinedBy rdf:resource="http://data.europa.eu/snb/model/elm"/>
+    <rdfs:label xml:lang="en">Mailbox</rdfs:label>
+    <rdfs:comment xml:lang="en">A mailbox.</rdfs:comment>
+    <dc:identifier>elm:Mailbox</dc:identifier>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </owl:Class>
   <owl:Class rdf:about="http://data.europa.eu/snb/model/elm/ShaclValidator2017">
     <rdfs:isDefinedBy rdf:resource="http://data.europa.eu/snb/model/elm"/>
     <rdfs:label xml:lang="en">Shacl Validator 2017</rdfs:label>
@@ -230,13 +237,6 @@
     <rdfs:label xml:lang="en">Learning Assessment Specification</rdfs:label>
     <rdfs:comment xml:lang="en">A Learning Assessment Specification is a specification of a process establishing the extent to which a learner has attained particular knowledge, skills and competences against criteria such as learning outcomes or standards of competence.</rdfs:comment>
     <dc:identifier>elm:LearningAssessmentSpecification</dc:identifier>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-  </owl:Class>
-  <owl:Class rdf:about="http://data.europa.eu/snb/model/elm/EmailAddress">
-    <rdfs:isDefinedBy rdf:resource="http://data.europa.eu/snb/model/elm"/>
-    <rdfs:label xml:lang="en">Email Address</rdfs:label>
-    <rdfs:comment xml:lang="en">An e-mail address.</rdfs:comment>
-    <dc:identifier>elm:EmailAddress</dc:identifier>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
   </owl:Class>
   <owl:Class rdf:about="http://data.europa.eu/snb/model/elm/ResultDistribution">
@@ -1053,7 +1053,7 @@
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:about="http://data.europa.eu/snb/model/elm/emailAddress">
-    <rdfs:range rdf:resource="http://data.europa.eu/snb/model/elm/EmailAddress"/>
+    <rdfs:range rdf:resource="http://data.europa.eu/snb/model/elm/Mailbox"/>
     <rdfs:domain rdf:resource="http://data.europa.eu/snb/model/elm/ContactPoint"/>
     <rdfs:isDefinedBy rdf:resource="http://data.europa.eu/snb/model/elm"/>
     <rdfs:label xml:lang="en">emailAddress</rdfs:label>

--- a/xsd/ams/ams.xsd
+++ b/xsd/ams/ams.xsd
@@ -134,7 +134,7 @@
    <xs:element name="contactPoint" type="ContactPointType"/>
    <xs:element name="group" type="GroupType"/>
    <xs:element name="identifier" type="IdentifierType"/>
-   <xs:element name="emailAddress" type="EmailAddressType"/>
+   <xs:element name="emailAddress" type="MailboxType"/>
    <xs:element name="phone" type="PhoneType"/>
 
    <!-- PROPERTIES  -->
@@ -622,9 +622,9 @@
       </xs:complexContent>
    </xs:complexType>
 
-   <xs:complexType name="EmailAddressType">
+   <xs:complexType name="MailboxType">
       <xs:annotation>
-         <xs:documentation>An e-mail address.</xs:documentation>
+         <xs:documentation>A mailbox.</xs:documentation>
       </xs:annotation>
       <xs:simpleContent>
          <xs:extension base="xs:anyURI"/>

--- a/xsd/loq/loq.xsd
+++ b/xsd/loq/loq.xsd
@@ -375,7 +375,7 @@
    <xs:element name="learningAssessmentSpecification" type="LearningAssessmentSpecificationType"/>
    <xs:element name="learningEntitlementSpecification" type="LearningEntitlementSpecificationType"/>
    <xs:element name="learningOpportunity" type="LearningOpportunityType"/>
-   <xs:element name="emailAddress" type="EmailAddressType"/>
+   <xs:element name="emailAddress" type="MailboxType"/>
    <xs:element name="phone" type="PhoneType"/>
    <xs:element name="priceDetail" type="PriceDetailType"/>
    <xs:element name="qualification" type="QualificationType"/>
@@ -1543,9 +1543,9 @@
       </xs:complexContent>
    </xs:complexType>
 
-   <xs:complexType name="EmailAddressType">
+   <xs:complexType name="MailboxType">
       <xs:annotation>
-         <xs:documentation>An e-mail address.</xs:documentation>
+         <xs:documentation>A mailbox.</xs:documentation>
       </xs:annotation>
       <xs:simpleContent>
          <xs:extension base="xs:anyURI"/>


### PR DESCRIPTION
This PR covers:
- update after reverting elm:EmailAddress class back to elm:Mailbox. The property is still elm:emailAddress