### PR TITLE
Remove limitCredentialType CV from EDC AP

### DIFF
--- a/rdf/ap/edc/EDC-generic-full.ttl
+++ b/rdf/ap/edc/EDC-generic-full.ttl
@@ -225,17 +225,6 @@
         sh:path skos:inScheme
     ] .
 
-:LimitCredentialTypeRestriction
-   a sh:NodeShape ;
-    rdfs:comment "Limit Credential Type Restriction";
-    rdfs:label "Limit Credential Type Restriction";
-    sh:property [
-        sh:class skos:ConceptScheme ;
-        sh:hasValue <http://data.europa.eu/snb/credential/25831c2> ;
-        sh:nodeKind sh:IRI ;
-        sh:path skos:inScheme
-    ] .
-
 :VerificationCheckStatusRestriction
     a sh:NodeShape ;
     rdfs:comment "Verification Check Status restriction" ;
@@ -296,13 +285,6 @@
         sh:nodeKind sh:IRI ;
         sh:name "accredited in jurisdiction"@en;
         sh:path elm:limitJurisdiction;
-        sh:severity sh:Violation;
-    ];
-    sh:property[
-        sh:node :LimitCredentialTypeRestriction;
-        sh:nodeKind sh:IRI ;
-        sh:name "limit credential type"@en;
-        sh:path elm:limitCredentialType;
         sh:severity sh:Violation;
     ];
 .

--- a/rdf/ap/edc/documentation/EDC-generic-full.html
+++ b/rdf/ap/edc/documentation/EDC-generic-full.html
@@ -249,7 +249,6 @@
             <li><a href="#:LearningEntitlementStatusRestriction">Learning Entitlement Status restriction</a></li>
             <li><a href="#:LearningOutcomeTypeRestriction">Learning Outcome Type restriction</a></li>
             <li><a href="#:LearningSettingRestriction">Learning Setting restriction</a></li>
-            <li><a href="#:LimitCredentialTypeRestriction">Limit Credential Type Restriction</a></li>
             <li><a href="#:NQFLevelRestriction">NQF Level restriction</a></li>
             <li><a href="#:ReusabilityLevelRestriction">Reusability Level restriction</a></li>
             <li><a href="#:ThematicAreaRestriction">Thematic Area restriction</a></li>
@@ -741,37 +740,6 @@
     </div>
 </div><br><div class="row mt-3">
     <div class="col">
-        <section id=":LimitCredentialTypeRestriction">
-            <div class="sp_section_title_table_wrapper">
-                <h2 class="sp_section_title_table">Limit Credential Type Restriction</h2>
-            </div>
-            <p><em>Limit Credential Type Restriction</em></p>
-            <table class="sp_table_propertyshapes table-striped table-responsive">
-                <thead>
-                <tr>
-                    <th>Property name</th>
-                    <th>URI</th>
-                    <th>Expected value</th>
-                    <th>Card.</th>
-                    <th class="sp_description_column">Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td></td>
-                    <td><code><a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a></code></td>
-                    <td><code>http://data.europa.eu/snb/credential/25831c2</code><br></td>
-                    <td>
-                        <div style="width:30px">0..*</div>
-                    </td>
-                    <td class="sp_table_propertyshapes_col_description"></td>
-                </tr>
-                </tbody>
-            </table>
-        </section>
-    </div>
-</div><br><div class="row mt-3">
-    <div class="col">
         <section id=":NQFLevelRestriction">
             <div class="sp_section_title_table_wrapper">
                 <h2 class="sp_section_title_table">NQF Level restriction</h2>
@@ -967,15 +935,6 @@
                     <td>accredited in jurisdiction</td>
                     <td><code><a href="http://data.europa.eu/snb/model/elm/limitJurisdiction">elm:limitJurisdiction</a></code></td>
                     <td><code><a href="#:JurisdictionRestriction">Jurisdiction restriction</a></code><br></td>
-                    <td>
-                        <div style="width:30px">0..*</div>
-                    </td>
-                    <td class="sp_table_propertyshapes_col_description"></td>
-                </tr>
-                <tr>
-                    <td>limit credential type</td>
-                    <td><code><a href="http://data.europa.eu/snb/model/elm/limitCredentialType">elm:limitCredentialType</a></code></td>
-                    <td><code><a href="#:LimitCredentialTypeRestriction">Limit Credential Type Restriction</a></code><br></td>
                     <td>
                         <div style="width:30px">0..*</div>
                     </td>

--- a/rdf/ap/edc/rdf-xml/EDC-generic-full.rdf
+++ b/rdf/ap/edc/rdf-xml/EDC-generic-full.rdf
@@ -206,24 +206,6 @@
   <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-full/AccreditationShapeCV">
     <sh:property rdf:parseType="Resource">
       <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
-      <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitCredentialType"/>
-      <sh:name xml:lang="en">limit credential type</sh:name>
-      <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
-      <sh:node>
-        <sh:NodeShape rdf:about="http://data.europa.eu/snb/model/ap/edc-generic-full/LimitCredentialTypeRestriction">
-          <sh:property rdf:parseType="Resource">
-            <sh:path rdf:resource="http://www.w3.org/2004/02/skos/core#inScheme"/>
-            <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>
-            <sh:hasValue rdf:resource="http://data.europa.eu/snb/credential/25831c2"/>
-            <sh:class rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-          </sh:property>
-          <rdfs:label>Limit Credential Type Restriction</rdfs:label>
-          <rdfs:comment>Limit Credential Type Restriction</rdfs:comment>
-        </sh:NodeShape>
-      </sh:node>
-    </sh:property>
-    <sh:property rdf:parseType="Resource">
-      <sh:severity rdf:resource="http://www.w3.org/ns/shacl#Violation"/>
       <sh:path rdf:resource="http://data.europa.eu/snb/model/elm/limitJurisdiction"/>
       <sh:name xml:lang="en">accredited in jurisdiction</sh:name>
       <sh:nodeKind rdf:resource="http://www.w3.org/ns/shacl#IRI"/>


### PR DESCRIPTION
This PR covers:
- removal of CV restriction for limitCredentialType property in EDC AP.
- update of EDC-generic-full.html documentation