### PR TITLE
fix: replace unicode symbol U+0399 with the more common U+0049 symbol

### DIFF
--- a/rdf/samples/credential-sample.jsonld
+++ b/rdf/samples/credential-sample.jsonld
@@ -55,7 +55,7 @@
       "en":"some legal name",
       "fr":"un nom légal"
       },
-    "eIDASΙdentifier": {
+    "eIDASIdentifier": {
       "id": "http://example.org/126839",
       "type": "LegalIdentifier",
       "notation": "126839",


### PR DESCRIPTION
> The character U+0399 "Ι" could be confused with the character U+0049 "I", which is more common in source code.

I realized this mismatch when I was comparing the [sample jsonld](https://github.com/european-commission-empl/European-Learning-Model/blob/master/rdf/samples/credential-sample.jsonld) with its [referenced context](http://data.europa.eu/snb/model/context/edc-ap).