### PR TITLE
ELM v3.2 - Replace Europass with European

### DIFF
--- a/rdf/ontology/ELM.ttl
+++ b/rdf/ontology/ELM.ttl
@@ -31,17 +31,17 @@
   owl:imports locn:;
   owl:imports clv:;
   owl:imports sec:;
-  rdfs:label "Europass Learning Model"@en;
+  rdfs:label "European Learning Model"@en;
   dc:created "2021-08-01"^^xsd:date;
   dc:modified "2023-07-06"^^xsd:date;
-  dc:title "Europass Learning Model Ontology"@en;
+  dc:title "European Learning Model Ontology"@en;
   dc:abstract '''Data Model for Interoperability of Learning Opportunities, Qualifications and Credentials in Europe. 
-  The Europass Learning Model aims to capture the results of any non-formal and formal learning across Europe, as well as 
+  The European Learning Model aims to capture the results of any non-formal and formal learning across Europe, as well as
   the validation of non-formal and informal learning. It is designed to provide a single format to describe certificates of attendance, 
   examination results, degrees and diplomas, diploma supplements, professional certifications, employer recommendations and any other kind 
   of claims that are related to learning'''@en;
   cc:attributionName "European Commission"@en;
-  rdfs:comment "This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as well as the ranges and domains of properties are defined in the application profiles that import the ELM ontology."@en;
+  rdfs:comment "This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as well as the ranges and domains of properties are defined in the application profiles that import the ELM ontology."@en;
   owl:versionInfo "3.2.0";
   dc:publisher <http://publications.europa.eu/resource/authority/corporate-body/DEMP>;
   cc:attributionURL <http://ec.europa.eu/> ;
@@ -208,7 +208,7 @@ elm:EuropeanDigitalCredential
    a rdfs:Class;
    a owl:Class;
    dc:identifier "elm:EuropeanDigitalCredential";
-   rdfs:comment "A set of claims made by an issuer in Europe, using the Europass Standards. A Europass credential is a set of one or more claims which may be used to demonstrate that the owner has certain skills or has achieved certain learning outcomes through formal, non-formal or informal learning."@en;
+   rdfs:comment "A set of claims made by an issuer in Europe, using the European Standards. A European credential is a set of one or more claims which may be used to demonstrate that the owner has certain skills or has achieved certain learning outcomes through formal, non-formal or informal learning."@en;
    rdfs:label "European Digital Credential"@en;
    rdfs:isDefinedBy <http://data.europa.eu/snb/model/elm>;
    rdfs:subClassOf cred:VerifiableCredential;
@@ -590,7 +590,7 @@ elm:status
   dc:identifier "elm:status";
 	rdfs:comment "The status. It can be the status of the verification check, Entitlement specification etc"@en;
   rdfs:label "status"@en;
-  skos:usageNote"It is recommended to be used with a controlled vocabulary. For the status of an entitlement the Europass Standard List of Entitlement Status Controlled vocabulary is recommended. Dor the status of the verification check the Europass Standard List of Verification Statuses is recommended. "@en;
+  skos:usageNote"It is recommended to be used with a controlled vocabulary. For the status of an entitlement the European Standard List of Entitlement Status Controlled vocabulary is recommended. Dor the status of the verification check the European Standard List of Verification Statuses is recommended. "@en;
 	rdfs:isDefinedBy <http://data.europa.eu/snb/model/elm>;
 .
 
@@ -981,7 +981,7 @@ elm:framework
   a rdf:Property;
 	a owl:ObjectProperty;
   dc:identifier "framework";
-	rdfs:comment "The framework used to assign the  credit points to the learning specification. It should be provided using the Europass Standard List of Educational Credit Systems."@en;
+	rdfs:comment "The framework used to assign the  credit points to the learning specification. It should be provided using the European Standard List of Educational Credit Systems."@en;
   rdfs:label "framework"@en;
 	rdfs:isDefinedBy <http://data.europa.eu/snb/model/elm>;
   .
@@ -1503,7 +1503,7 @@ elm:idVerification
 	a owl:ObjectProperty;
   dc:identifier "elm:idVerification";
 	rdfs:comment "Method of assessment supervision and id verification."@en;
-  skos:usageNote "It is recommended to be used with Europass Standard List of Methods Of Supervision And Verification controlled vocabulary."@en;
+  skos:usageNote "It is recommended to be used with European Standard List of Methods Of Supervision And Verification controlled vocabulary."@en;
   rdfs:label "ID verification"@en;
 	rdfs:isDefinedBy <http://data.europa.eu/snb/model/elm>;
   rdfs:domain elm:LearningAssessment;

--- a/rdf/ontology/documentation/elm-v3.2.0-config.properties
+++ b/rdf/ontology/documentation/elm-v3.2.0-config.properties
@@ -1,9 +1,9 @@
 
-abstract=This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.
-ontologyTitle=Europass Learning Model Ontology
+abstract=This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.
+ontologyTitle=European Learning Model Ontology
 ontologyPrefix=elm
 ontologyNamespaceURI=http://data.europa.eu/snb/model/elm
-ontologyName=Europass Learning Model
+ontologyName=European Learning Model
 thisVersionURI=http://data.europa.eu/snb/model/elm
 latestVersionURI=http://data.europa.eu/snb/model/elm
 previousVersionURI=
@@ -12,7 +12,7 @@ ontologyRevisionNumber=3.2.0
 licenseURI=https://creativecommons.org/licenses/by/4.0/
 licenseName=https://creativecommons.org/licenses/by/4.0/
 licenseIconURL=https://i.creativecommons.org/l/by/4.0/88x31.png
-citeAs= Europass Learning Model Ontology. Revision: 3.2.0.
+citeAs= European Learning Model Ontology. Revision: 3.2.0.
 DOI=
 status=
 backwardsCompatibleWith=

--- a/rdf/ontology/documentation/index-bg.html
+++ b/rdf/ontology/documentation/index-bg.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:40 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:58 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-bg.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-cs.html
+++ b/rdf/ontology/documentation/index-cs.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:13 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:15 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Citujte jako:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-cs.html" target="_blank">Provenance této stránky</a><hr/>
 </div>
      <div id="abstract"><h2>Abstrakt</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ Toto je místo pro Úvod. Úvod by měl krátce popsat obsah ontologie, její mo
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Přehled <span class="backlink"> zpět k <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Přehled <span class="backlink"> zpět k <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 Tato ontologie má následující třídy a vlastnosti.</span>
 <h4>Třídy</h4>
@@ -876,7 +876,7 @@ Tato ontologie má následující třídy a vlastnosti.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Popis <span class="backlink"> zpět k <a href="#toc">obsahu</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Popis <span class="backlink"> zpět k <a href="#toc">obsahu</a></span></h2>
 <span class="markdown">
 Toto je místo pro popis ontologie. Popis má obsahovat vysvětlení a diagram ukazující vztahy mezi třídami, příklady použití, atd.</span>
 
@@ -884,8 +884,8 @@ Toto je místo pro popis ontologie. Popis má obsahovat vysvětlení a diagram u
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Křížový odkaz pro Europass Learning Model třídy, objektové vlastnosti a datové vlastnosti <span class="backlink"> zpět k <a href="#toc">obsahu</a></span></h2>
-Tato sekce poskytuje detaily pro každou třídu a vlastnost definovanou Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Křížový odkaz pro European Learning Model třídy, objektové vlastnosti a datové vlastnosti <span class="backlink"> zpět k <a href="#toc">obsahu</a></span></h2>
+Tato sekce poskytuje detaily pro každou třídu a vlastnost definovanou European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Třídy</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-da.html
+++ b/rdf/ontology/documentation/index-da.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:16 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:17 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-da.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-de.html
+++ b/rdf/ontology/documentation/index-de.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:31 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:54 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-de.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-el.html
+++ b/rdf/ontology/documentation/index-el.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:02 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:09 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-el.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-en.html
+++ b/rdf/ontology/documentation/index-en.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:24 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:47 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-en.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">
@@ -1488,7 +1488,7 @@ This section provides details for each class and property defined by Europass Le
       <p>
          <strong>IRI:</strong> http://data.europa.eu/snb/model/elm/EuropeanDigitalCredential</p>
       <div class="comment">
-         <span class="markdown">A set of claims made by an issuer in Europe, using the Europass Standards. A Europass credential is a set of one or more claims which may be used to demonstrate that the owner has certain skills or has achieved certain learning outcomes through formal, non-formal or informal learning.</span>
+         <span class="markdown">A set of claims made by an issuer in Europe, using the European Standards. A European credential is a set of one or more claims which may be used to demonstrate that the owner has certain skills or has achieved certain learning outcomes through formal, non-formal or informal learning.</span>
       </div>
       <dl class="definedBy">
          <dt>Is defined by</dt>
@@ -4722,7 +4722,7 @@ If provided, the value should come from a controlled vocabulary. Data providers 
       <p>
          <strong>IRI:</strong> http://data.europa.eu/snb/model/elm/framework</p>
       <div class="comment">
-         <span class="markdown">The framework used to assign the  credit points to the learning specification. It should be provided using the Europass Standard List of Educational Credit Systems.</span>
+         <span class="markdown">The framework used to assign the  credit points to the learning specification. It should be provided using the European Standard List of Educational Credit Systems.</span>
       </div>
       <dl class="definedBy">
          <dt>Is defined by</dt>

--- a/rdf/ontology/documentation/index-es.html
+++ b/rdf/ontology/documentation/index-es.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:09 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:13 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Citar como:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-es.html" target="_blank">Provenance de esta p&aacute;gina</a><hr/>
 </div>
      <div id="abstract"><h2>S&iacute;ntesis</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -91,7 +91,7 @@ This document specifies the set of RDF/OWL classes and properties used in the Eu
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Resumen <span class="backlink"> volver a <a href="#toc">&iacute;ndice</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Resumen <span class="backlink"> volver a <a href="#toc">&iacute;ndice</a></span></h2>
 <span class="markdown">La ontolog&iacute;a se compone de las siguientes clases y propiedades:</span>
 <h4>Clases</h4>
 <ul xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" class="hlist">
@@ -874,15 +874,15 @@ This document specifies the set of RDF/OWL classes and properties used in the Eu
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Descripci&oacute;n <span class="backlink"> volver a <a href="#toc">&iacute;ndice</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Descripci&oacute;n <span class="backlink"> volver a <a href="#toc">&iacute;ndice</a></span></h2>
 <span class="markdown">Descripci&oacute;n completa de la ontolog&iacute;a: en caso de ser posible, a&ntilde;adir un diagrama explicando c&oacute;omo las clases est&aacute;n relacionadas, ejemplos de uso, etc.</span>
 
 </div>
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">T&eacute;rminos de Europass Learning Model para clases, propiedades y propiedades de datos <span class="backlink"> volver a <a href="#toc">&iacute;ndice</a></span></h2>
-Esta secci&oacute;n introduce m&aacute;s detalles sobre cada clase y propiedad definida por Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">T&eacute;rminos de European Learning Model para clases, propiedades y propiedades de datos <span class="backlink"> volver a <a href="#toc">&iacute;ndice</a></span></h2>
+Esta secci&oacute;n introduce m&aacute;s detalles sobre cada clase y propiedad definida por European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Clases</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-et.html
+++ b/rdf/ontology/documentation/index-et.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:11 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:14 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-et.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-fi.html
+++ b/rdf/ontology/documentation/index-fi.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:36 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:56 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-fi.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-fr.html
+++ b/rdf/ontology/documentation/index-fr.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:47 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:02 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Citer en tant que:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-fr.html" target="_blank">Provenance de cette page</a><hr/>
 </div>
      <div id="abstract"><h2>R&eacute;sum&eacute;</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ Ceci est une introduction automatique. L'introduction doit d&eacute;crire bri&eg
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Aper&ccedil;u <span class="backlink"> retour au <a href="#toc">sommaire</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Aper&ccedil;u <span class="backlink"> retour au <a href="#toc">sommaire</a></span></h2>
 <span class="markdown">
 Cette ontologie a les classes et propri&eacute;t&eacute;s suivantes.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ Cette ontologie a les classes et propri&eacute;t&eacute;s suivantes.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> retour au <a href="#toc">sommaire</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> retour au <a href="#toc">sommaire</a></span></h2>
 <span class="markdown">
 Ceci est une description automatique pour l'ontologie. La description doit comprendre un texte explicatif ainsi que des diagrammes illustrant comment les classes sont li&eacute;es, des exemples d'utilisation, etc.</span>
 
@@ -884,8 +884,8 @@ Ceci est une description automatique pour l'ontologie. La description doit compr
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">R&eacute;ference crois&eacute;e pour Europass Learning Model classes, propri&eacute;t&eacute;s et data-propri&eacute;t&eacute;s <span class="backlink"> retour au <a href="#toc">sommaire</a></span></h2>
-Cette section donne les d&eacute;tails de chaque classe et propri&eacute;t&eacute; d&eacute;finie par Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">R&eacute;ference crois&eacute;e pour European Learning Model classes, propri&eacute;t&eacute;s et data-propri&eacute;t&eacute;s <span class="backlink"> retour au <a href="#toc">sommaire</a></span></h2>
+Cette section donne les d&eacute;tails de chaque classe et propri&eacute;t&eacute; d&eacute;finie par European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-ga.html
+++ b/rdf/ontology/documentation/index-ga.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:55 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:05 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-ga.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-hr.html
+++ b/rdf/ontology/documentation/index-hr.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:44 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:00 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-hr.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-hu.html
+++ b/rdf/ontology/documentation/index-hu.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:49 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:03 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-hu.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-is.html
+++ b/rdf/ontology/documentation/index-is.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:06 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:11 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-is.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-it.html
+++ b/rdf/ontology/documentation/index-it.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:07 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:12 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cita come:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-it.html" target="_blank">Provenance (Origine) di questa pagina</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ Qui va inserita l'introduzione. L'introduzione dovrebbe descrivere brevemente l'
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> torna alla <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> torna alla <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 Questa ontologia definisce le seguenti classe e proprietÃ .</span>
 <h4>Classi</h4>
@@ -876,7 +876,7 @@ Questa ontologia definisce le seguenti classe e proprietÃ .</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Descrizione <span class="backlink"> torna alla <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Descrizione <span class="backlink"> torna alla <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 Qui va inserita la descrizione dell'ontologia. la descrizione dovrebbe includere una spiegazione e diagrammi, per spiegare le relazioni tra le classi, esempio di utilizzo, etc.</span>
 
@@ -884,8 +884,8 @@ Qui va inserita la descrizione dell'ontologia. la descrizione dovrebbe includere
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference per Europass Learning Model classi, proprietÃ  e dataproperty <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-Questa sezione fornisce i dettagli per ogni classe e proprietÃ  definita da Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference per European Learning Model classi, proprietÃ  e dataproperty <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+Questa sezione fornisce i dettagli per ogni classe e proprietÃ  definita da European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classi</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-lt.html
+++ b/rdf/ontology/documentation/index-lt.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:42 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:59 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-lt.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-lv.html
+++ b/rdf/ontology/documentation/index-lv.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:46 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:01 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-lv.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-mk.html
+++ b/rdf/ontology/documentation/index-mk.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:57 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:06 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-mk.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-mt.html
+++ b/rdf/ontology/documentation/index-mt.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:04 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:10 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-mt.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-nl.html
+++ b/rdf/ontology/documentation/index-nl.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:20 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:18 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-nl.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-no.html
+++ b/rdf/ontology/documentation/index-no.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:34 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:55 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-no.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-pl.html
+++ b/rdf/ontology/documentation/index-pl.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:14 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:16 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-pl.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-pt.html
+++ b/rdf/ontology/documentation/index-pt.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:38 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:19:57 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite como:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-pt.html" target="_blank">Hist&oacute;ria desta p&aacute;gina</a><hr/>
 </div>
      <div id="abstract"><h2>Sum&aacute;rio</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -91,7 +91,7 @@ This document specifies the set of RDF/OWL classes and properties used in the Eu
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Vis&atilde;o geral <span class="backlink"> de volta a <a href="#toc">&iacute;ndice</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Vis&atilde;o geral <span class="backlink"> de volta a <a href="#toc">&iacute;ndice</a></span></h2>
 <span class="markdown">Vis&atilde;o geral da ontologia vai aqui: algumas frases explicando os principais conceitos da ontologia</span>
 <h4>Classes</h4>
 <ul xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" class="hlist">
@@ -874,15 +874,15 @@ This document specifies the set of RDF/OWL classes and properties used in the Eu
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Descri&ccedil;&atilde;o <span class="backlink"> de volta a <a href="#toc">&iacute;ndice</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Descri&ccedil;&atilde;o <span class="backlink"> de volta a <a href="#toc">&iacute;ndice</a></span></h2>
 <span class="markdown">Descri&ccedil;&atilde;o completa da ontologia: um diagrama que explica como as classes est&atilde;o relacionadas, exemplos de utiliza&ccedil;&atilde;o, etc.</span>
 
 </div>
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Termos de Europass Learning Model classes, propriedades e propriedades de dados <span class="backlink"> de volta a <a href="#toc">&iacute;ndice</a></span></h2>
-Esta se&ccedil;&atilde;o fornece detalhes sobre cada classe e propriedade definida por Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Termos de European Learning Model classes, propriedades e propriedades de dados <span class="backlink"> de volta a <a href="#toc">&iacute;ndice</a></span></h2>
+Esta se&ccedil;&atilde;o fornece detalhes sobre cada classe e propriedade definida por European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-ro.html
+++ b/rdf/ontology/documentation/index-ro.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:18 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:17 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-ro.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-sk.html
+++ b/rdf/ontology/documentation/index-sk.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:51 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:04 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-sk.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-sl.html
+++ b/rdf/ontology/documentation/index-sl.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:53 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:05 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-sl.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-sr.html
+++ b/rdf/ontology/documentation/index-sr.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:37:58 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:07 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-sr.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-sv.html
+++ b/rdf/ontology/documentation/index-sv.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:00 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:08 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-sv.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/index-tr.html
+++ b/rdf/ontology/documentation/index-tr.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>Europass Learning Model Ontology</title>
+ <link rel="stylesheet" href="resources/primer.css" media="screen" />    <link rel="stylesheet" href="resources/rec.css" media="screen" />    <link rel="stylesheet" href="resources/extra.css" media="screen" />    <link rel="stylesheet" href="resources/owl.css" media="screen" />    <title>European Learning Model Ontology</title>
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"Europass Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Jul 19 16:38:21 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"http://data.europa.eu/snb/model/elm","image":"http://vowl.visualdataweb.org/webvowl/#iri=http://data.europa.eu/snb/model/elm","name":"European Learning Model Ontology", "headline":"This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.", "datePublished":"Wed Sep 13 14:20:19 CEST 2023", "version":"3.2.0", "license":"https://creativecommons.org/licenses/by/4.0/"}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -54,7 +54,7 @@ $(function(){
 <div class="container">
 <div class="head">
 <div style="float:right">language <a href="index-de.html"><b>de</b></a> <a href="index-no.html"><b>no</b></a> <a href="index-fi.html"><b>fi</b></a> <a href="index-pt.html"><b>pt</b></a> <a href="index-bg.html"><b>bg</b></a> <a href="index-lt.html"><b>lt</b></a> <a href="index-hr.html"><b>hr</b></a> <a href="index-lv.html"><b>lv</b></a> <a href="index-fr.html"><b>fr</b></a> <a href="index-hu.html"><b>hu</b></a> <a href="index-sk.html"><b>sk</b></a> <a href="index-sl.html"><b>sl</b></a> <a href="index-ga.html"><b>ga</b></a> <a href="index-mk.html"><b>mk</b></a> <a href="index-sr.html"><b>sr</b></a> <a href="index-sv.html"><b>sv</b></a> <a href="index-el.html"><b>el</b></a> <a href="index-mt.html"><b>mt</b></a> <a href="index-en.html"><b>en</b></a> <a href="index-is.html"><b>is</b></a> <a href="index-it.html"><b>it</b></a> <a href="index-es.html"><b>es</b></a> <a href="index-et.html"><b>et</b></a> <a href="index-cs.html"><b>cs</b></a> <a href="index-pl.html"><b>pl</b></a> <a href="index-da.html"><b>da</b></a> <a href="index-ro.html"><b>ro</b></a> <a href="index-nl.html"><b>nl</b></a> <a href="index-tr.html"><b>tr</b></a> </div>
-<h1>Europass Learning Model Ontology</h1>
+<h1>European Learning Model Ontology</h1>
 
 
 <dl>
@@ -74,13 +74,13 @@ $(function(){
 <img src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0" alt="License" />
 </a>
 <br/></dd><!-- <dt>Evaluation:</dt><dd><a href="OOPSEvaluation/oopsEval.html#" target="_blank"><img src="https://img.shields.io/badge/Evaluate_with-OOPS! (OntOlogy Pitfall Scanner!)-blue.svg" alt="Evaluate with OOPS!" /></a></dd> --><dt>Cite as:</dt>
-<dd>Europass Learning Model Ontology. Revision: 3.2.0.</dd>
+<dd>European Learning Model Ontology. Revision: 3.2.0.</dd>
 </dl>
 
 <a href="provenance/provenance-tr.html" target="_blank">Provenance of this page</a><hr/>
 </div>
      <div id="abstract"><h2>Abstract</h2><span class="markdown">
-This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
+This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as weel as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</span>
 </div>
 <div id="toc"></div> 
 
@@ -92,7 +92,7 @@ This is a place holder text for the introduction. The introduction should briefl
   
 
 <!--OVERVIEW SECTION-->
-    <div id="overview"><h2 id="overv" class="list">Europass Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="overview"><h2 id="overv" class="list">European Learning Model: Overview <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
@@ -876,7 +876,7 @@ This ontology has the following classes and properties.</span>
   
 
 <!--DESCRIPTION SECTION-->
-    <div id="description"><h2 id="desc" class="list">Europass Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+    <div id="description"><h2 id="desc" class="list">European Learning Model: Description <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
 This is a placeholder text for the description of your ontology. The description should include an explanation and a diagram explaining how the classes are related, examples of usage, etc.</span>
 
@@ -884,8 +884,8 @@ This is a placeholder text for the description of your ontology. The description
    
 
 <!--CROSSREF SECTION-->
-   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for Europass Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
-This section provides details for each class and property defined by Europass Learning Model.
+   <div id="crossref"><h2 id="crossreference" class="list">Cross reference for European Learning Model classes, properties and dataproperties <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
+This section provides details for each class and property defined by European Learning Model.
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="classes">
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">

--- a/rdf/ontology/documentation/provenance/provenance-bg.html
+++ b/rdf/ontology/documentation/provenance/provenance-bg.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-bg.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-bg.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-cs.html
+++ b/rdf/ontology/documentation/provenance/provenance-cs.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance pro Europass Learning Model Ontology Dokumentace (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance pro European Learning Model Ontology Dokumentace (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm je specializací obecného IRI http://data.europa.eu/snb/model/elm</li>
 <li>Dokumentace ontologie byla výsledkem použití <a href="https://github.com/dgarijo/Widoco">nástroje Widoco</a> (který využívá <a href="http://www.essepuntato.it/lode/">LODE</a> pro generování křížových odkazů).</li>

--- a/rdf/ontology/documentation/provenance/provenance-cs.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-cs.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-da.html
+++ b/rdf/ontology/documentation/provenance/provenance-da.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-da.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-da.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-de.html
+++ b/rdf/ontology/documentation/provenance/provenance-de.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-de.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-de.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-el.html
+++ b/rdf/ontology/documentation/provenance/provenance-el.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-el.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-el.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-en.html
+++ b/rdf/ontology/documentation/provenance/provenance-en.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-en.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-en.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-es.html
+++ b/rdf/ontology/documentation/provenance/provenance-es.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance para la documentaci&oacute;n de Europass Learning Model Ontology . (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance para la documentaci&oacute;n de European Learning Model Ontology . (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm es una especializaci&oacute;n de la URI gen&eacute;rica: http://data.europa.eu/snb/model/elm</li>
 <li>La documentaci&oacute;n de la ontolog&iacute;a es el resultado de la utilizaci&oacute;n de la herramienta <a href="https://github.com/dgarijo/Widoco">Widoco</a> (que a su vez utiliza <a href="http://www.essepuntato.it/lode/">LODE</a> para la generaci&oacute;n de la secci&oacute;n de t&eacute;rminos de la ontolog&iacute;a).</li>

--- a/rdf/ontology/documentation/provenance/provenance-es.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-es.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-et.html
+++ b/rdf/ontology/documentation/provenance/provenance-et.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-et.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-et.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-fi.html
+++ b/rdf/ontology/documentation/provenance/provenance-fi.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-fi.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-fi.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-fr.html
+++ b/rdf/ontology/documentation/provenance/provenance-fr.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance pour Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance pour European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm est une sp&eacute;cialisation de l'URI g&eacute;n&eacute;rique http://data.europa.eu/snb/model/elm</li>
 <li>La documentation de l'ontologie r&eacute;sulte de l'utilisation de <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (qui utilise <a href="http://www.essepuntato.it/lode/">LODE</a> pour g&eacute;n&eacute;rer les sections de r&eacute;f&eacute;rencement crois&eacute;).</li>

--- a/rdf/ontology/documentation/provenance/provenance-fr.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-fr.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-ga.html
+++ b/rdf/ontology/documentation/provenance/provenance-ga.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-ga.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-ga.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-hr.html
+++ b/rdf/ontology/documentation/provenance/provenance-hr.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-hr.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-hr.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-hu.html
+++ b/rdf/ontology/documentation/provenance/provenance-hu.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-hu.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-hu.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-is.html
+++ b/rdf/ontology/documentation/provenance/provenance-is.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-is.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-is.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-it.html
+++ b/rdf/ontology/documentation/provenance/provenance-it.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance per Europass Learning Model Ontology Documentazione (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance per European Learning Model Ontology Documentazione (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm Ã¨ una specializzazione della URI generica  http://data.europa.eu/snb/model/elm</li>
 <li>La documentazione dell'ontologia Ã¨ stata prodotta usando il programma <a href="https://github.com/dgarijo/Widoco">Widoco</a> (che a sua volta usa <a href="http://www.essepuntato.it/lode/">LODE</a> per generare la sezione dei riferimenti incrociati).</li>

--- a/rdf/ontology/documentation/provenance/provenance-it.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-it.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-lt.html
+++ b/rdf/ontology/documentation/provenance/provenance-lt.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-lt.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-lt.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-lv.html
+++ b/rdf/ontology/documentation/provenance/provenance-lv.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-lv.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-lv.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-mk.html
+++ b/rdf/ontology/documentation/provenance/provenance-mk.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-mk.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-mk.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-mt.html
+++ b/rdf/ontology/documentation/provenance/provenance-mt.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-mt.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-mt.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-nl.html
+++ b/rdf/ontology/documentation/provenance/provenance-nl.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-nl.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-nl.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-no.html
+++ b/rdf/ontology/documentation/provenance/provenance-no.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-no.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-no.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-pl.html
+++ b/rdf/ontology/documentation/provenance/provenance-pl.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-pl.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-pl.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-pt.html
+++ b/rdf/ontology/documentation/provenance/provenance-pt.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Proveni&ecirc;ncia para Europass Learning Model Ontology Documenta&ccedil;&atilde;o (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Proveni&ecirc;ncia para European Learning Model Ontology Documenta&ccedil;&atilde;o (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm &eacute; uma especializa&ccedil;&atilde;o da URI gen&eacute;rico http://data.europa.eu/snb/model/elm</li>
 <li>A documenta&ccedil;&atilde;o ontologia foi o resultado do uso da <a href="https://github.com/dgarijo/Widoco">ferramenta Widoco</a> (que se utiliza <a href="http://www.essepuntato.it/lode/">LODE</a> para gerar a sec&ccedil;&atilde;o em termos de ontologia).</li>

--- a/rdf/ontology/documentation/provenance/provenance-pt.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-pt.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-ro.html
+++ b/rdf/ontology/documentation/provenance/provenance-ro.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-ro.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-ro.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-sk.html
+++ b/rdf/ontology/documentation/provenance/provenance-sk.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-sk.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-sk.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-sl.html
+++ b/rdf/ontology/documentation/provenance/provenance-sl.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-sl.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-sl.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-sr.html
+++ b/rdf/ontology/documentation/provenance/provenance-sr.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-sr.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-sr.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-sv.html
+++ b/rdf/ontology/documentation/provenance/provenance-sv.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-sv.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-sv.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/documentation/provenance/provenance-tr.html
+++ b/rdf/ontology/documentation/provenance/provenance-tr.html
@@ -7,7 +7,7 @@
 
 <body>
 <div class="head">
-<h1>Provenance for Europass Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
+<h1>Provenance for European Learning Model Ontology Documentation (http://data.europa.eu/snb/model/elm)</h1>
 <ul>
 <li>http://data.europa.eu/snb/model/elm is a specialization of the generic URI http://data.europa.eu/snb/model/elm</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>

--- a/rdf/ontology/documentation/provenance/provenance-tr.ttl
+++ b/rdf/ontology/documentation/provenance/provenance-tr.ttl
@@ -3,7 +3,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix : <> .
 <http://data.europa.eu/snb/model/elm> a prov:Entity;
-	 dc:title "Europass Learning Model Ontology";
+	 dc:title "European Learning Model Ontology";
 	 prov:wasAttributedTo <https://github.com/dgarijo/Widoco/>,<http://www.essepuntato.it/lode/>;
 	 prov:specializationOf <http://data.europa.eu/snb/model/elm>;
 .

--- a/rdf/ontology/rdf-xml/ELM.rdf
+++ b/rdf/ontology/rdf-xml/ELM.rdf
@@ -20,13 +20,14 @@
     <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2021-08-01</dc:created>
     <owl:imports rdf:resource="http://www.w3.org/ns/locn#"/>
-    <rdfs:label xml:lang="en">Europass Learning Model</rdfs:label>
     <owl:imports rdf:resource="https://w3id.org/security#"/>
     <owl:imports rdf:resource="http://www.w3.org/ns/regorg#"/>
     <owl:imports rdf:resource="http://data.europa.eu/snb/model/elm/"/>
     <cc:attributionURL rdf:resource="http://ec.europa.eu/"/>
     <cc:attributionName xml:lang="en">European Commission</cc:attributionName>
     <dc:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/DEMP"/>
+    <rdfs:label xml:lang="en">European Learning Model</rdfs:label>
+    <rdfs:comment xml:lang="en">This document specifies the set of RDF/OWL classes and properties used in the European Learning Model. The associations between classes and properties, as well as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</rdfs:comment>
     <dc:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2023-07-06</dc:modified>
     <owl:imports rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
@@ -39,17 +40,16 @@
     </dc:license>
     <owl:imports rdf:resource="http://www.w3.org/ns/person#"/>
     <owl:imports rdf:resource="https://www.w3.org/2018/credentials#"/>
-    <dc:title xml:lang="en">Europass Learning Model Ontology</dc:title>
     <owl:imports rdf:resource="http://data.europa.eu/m8g/"/>
-    <owl:versionInfo>3.2.0</owl:versionInfo>
-    <owl:imports rdf:resource="http://www.w3.org/ns/adms#"/>
-    <rdfs:comment xml:lang="en">This document specifies the set of RDF/OWL classes and properties used in the Europass Learning Model. The associations between classes and properties, as well as the ranges and domains of properties are defined in the application profiles that import the ELM ontology.</rdfs:comment>
-    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
     <dc:abstract xml:lang="en">Data Model for Interoperability of Learning Opportunities, Qualifications and Credentials in Europe. 
-  The Europass Learning Model aims to capture the results of any non-formal and formal learning across Europe, as well as 
+  The European Learning Model aims to capture the results of any non-formal and formal learning across Europe, as well as
   the validation of non-formal and informal learning. It is designed to provide a single format to describe certificates of attendance, 
   examination results, degrees and diplomas, diploma supplements, professional certifications, employer recommendations and any other kind 
   of claims that are related to learning</dc:abstract>
+    <owl:versionInfo>3.2.0</owl:versionInfo>
+    <owl:imports rdf:resource="http://www.w3.org/ns/adms#"/>
+    <dc:title xml:lang="en">European Learning Model Ontology</dc:title>
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
     <owl:imports rdf:resource="http://xmlns.com/foaf/0.1/"/>
     <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
   </owl:Ontology>
@@ -1759,7 +1759,6 @@
     <rdfs:label xml:lang="lt">Europos skaitmeninis kredencialas</rdfs:label>
     <rdfs:comment xml:lang="ga">Cineál speisialta dintiúir infhíoraithe a úsáidtear chun sonraí foghlama agus fostaíochta a chur in iúl, i gcomhréir leis an Moladh ón gComhairle an 22 Bealtaine 2017 maidir leis an gCreat Eorpach um Cháilíochtaí don fhoghlaim ar feadh an tsaoil.</rdfs:comment>
     <rdfs:comment xml:lang="pl">Specjalny rodzaj weryfikowalnego poświadczenia wykorzystywanego do wyrażenia danych dotyczących uczenia się i zatrudnienia, zgodnie z zaleceniem Rady z dnia 22 maja 2017 r. w sprawie europejskich ram kwalifikacji dla uczenia się przez całe życie.</rdfs:comment>
-    <rdfs:comment xml:lang="en">A set of claims made by an issuer in Europe, using the Europass Standards. A Europass credential is a set of one or more claims which may be used to demonstrate that the owner has certain skills or has achieved certain learning outcomes through formal, non-formal or informal learning.</rdfs:comment>
     <rdfs:label xml:lang="bg">Европейско цифрово удостоверение</rdfs:label>
     <rdfs:label xml:lang="et">Euroopa digitaalne õppetõend</rdfs:label>
     <rdfs:comment xml:lang="el">Ειδικός τύπος επαληθεύσιμου διαπιστευτηρίου που χρησιμοποιείται για την έκφραση δεδομένων μάθησης και απασχόλησης, σύμφωνα με τη σύσταση του Συμβουλίου, της 22ας Μαΐου 2017, σχετικά με το ευρωπαϊκό πλαίσιο επαγγελματικών προσόντων για τη διά βίου μάθηση.</rdfs:comment>
@@ -1780,6 +1779,7 @@
     <rdfs:comment xml:lang="lv">Pārbaudāma apliecinājuma dokumenta īpašs tips, ko izmanto, lai sniegtu mācību un nodarbinātības datus saskaņā ar Padomes 2017. gada 22. maija Ieteikumu par Eiropas kvalifikāciju ietvarstruktūru mūžizglītībai.</rdfs:comment>
     <rdfs:comment xml:lang="es">Un tipo especial de credencial verificable utilizado para expresar datos de aprendizaje y empleo, en consonancia con la Recomendación del Consejo, de 22 de mayo de 2017, relativa al Marco Europeo de Cualificaciones para el aprendizaje permanente.</rdfs:comment>
     <rdfs:label xml:lang="sk">Európsky digitálny certifikát</rdfs:label>
+    <rdfs:comment xml:lang="en">A set of claims made by an issuer in Europe, using the European Standards. A European credential is a set of one or more claims which may be used to demonstrate that the owner has certain skills or has achieved certain learning outcomes through formal, non-formal or informal learning.</rdfs:comment>
     <rdfs:comment xml:lang="cs">Zvláštní typ ověřitelného certifikátu, který se používá k vyjádření údajů o vzdělávání a zaměstnání v souladu s doporučením Rady ze dne 22. května 2017 o evropském rámci kvalifikací pro celoživotní učení.</rdfs:comment>
     <rdfs:label xml:lang="da">Europæisk digitalt eksamensbevis</rdfs:label>
     <rdfs:comment xml:lang="fi">Erityinen todennettava osaamistodistus, jota käytetään oppimiseen ja työkokemukseen liittyvien tietojen ilmaisemiseen eurooppalaisesta tutkintojen viitekehyksestä elinikäisen oppimisen edistämiseksi 22 päivänä toukokuuta 2017 annetun neuvoston suosituksen mukaisesti.</rdfs:comment>
@@ -3769,7 +3769,6 @@ Var norādīt tikai vērtības, kas ņemtas no akreditācijas statusu kontrolēt
     <rdfs:comment xml:lang="sl">Status objave zagotavljanja kakovosti ali licenciranja organizacije ali kvalifikacije.
 Če je vrednost navedena, mora izhajati iz kontroliranega besednjaka za status akreditacije (http://publications.europa.eu/resource/dataset/accreditation-status).</rdfs:comment>
     <rdfs:label xml:lang="sr">0.0</rdfs:label>
-    <skos:usageNote xml:lang="en">It is recommended to be used with a controlled vocabulary. For the status of an entitlement the Europass Standard List of Entitlement Status Controlled vocabulary is recommended. Dor the status of the verification check the Europass Standard List of Verification Statuses is recommended. </skos:usageNote>
     <rdfs:label xml:lang="pt">Estatuto</rdfs:label>
     <dc:identifier>elm:status</dc:identifier>
     <rdfs:label xml:lang="el">Κατάσταση</rdfs:label>
@@ -3793,6 +3792,7 @@ Falls angegeben, muss der Wert aus dem kontrollierten Vokabular für den Akkredi
 Jos arvo määritellään, sen on oltava kontrolloidusta sanastosta Akkreditoinnin tila(http://publications.europa.eu/resource/dataset/accreditation-status).</rdfs:comment>
     <rdfs:comment xml:lang="sv">Publiceringsstatusen för kvalitetssäkringen eller licensieringen av en organisation eller en kvalifikation.
 I förekommande fall måste värdet komma från den kontrollerade ordlistan för ackrediteringsstatusen (http://publications.europa.eu/resource/dataset/accreditation-status).</rdfs:comment>
+    <skos:usageNote xml:lang="en">It is recommended to be used with a controlled vocabulary. For the status of an entitlement the European Standard List of Entitlement Status Controlled vocabulary is recommended. Dor the status of the verification check the European Standard List of Verification Statuses is recommended. </skos:usageNote>
     <rdfs:comment xml:lang="lt">Organizacijos arba kvalifikacijos kokybės užtikrinimo arba licencijavimo skelbimo būsena.
 Jei nurodoma, vertė turi būti iš akreditacijų būsenų kontrolinio žodyno (http://publications.europa.eu/resource/dataset/accreditation-status).</rdfs:comment>
     <rdfs:comment xml:lang="tr">Kalite güvencesi veya bir niteliğin veya bir kuruluşu ruhsatlandırmasının yayınlanma durumu. Verilmişse, değerin Akreditasyon durumu kontrol edilmiş sözlükten gelmesi zorunludur (http://publications.europa.eu/resource/dataset/accreditation-status).</rdfs:comment>
@@ -7943,7 +7943,6 @@ Il nome del sistema di crediti utilizzato dovrebbe essere tratto da un vocabolar
     <rdfs:label xml:lang="no">rammeverk</rdfs:label>
     <rdfs:comment xml:lang="mk">Рамка која се користи за доделување на кредитни поени на спецификацијата на учење. Името на употребениот кредитен систем треба да биде од контролиран вокабулар (e.g. http://publications.europa.eu/resource/dataset/education-credit). Давателите на податоци можат да користат сопствена котролирана листа(и).</rdfs:comment>
     <rdfs:comment xml:lang="no">Rammeverket som brukes for å tildele studiepoeng til læringsspesifikasjonen. Navnet på det brukte kredittsystemet skal komme fra et kontrollert vokabular (e.g. http://publications.europa.eu/resource/dataset/education-credit). Dataleverandører kan bruke sin(e) egen/egne kontrollerte liste(r).</rdfs:comment>
-    <rdfs:comment xml:lang="en">The framework used to assign the  credit points to the learning specification. It should be provided using the Europass Standard List of Educational Credit Systems.</rdfs:comment>
     <rdfs:comment xml:lang="is">Ramminn sem notaður er til að úthluta námseiningum í námsskilmála. Heiti einingakerfis sem notað er þarf að koma úr stýrðum orðaforða (e.g. http://publications.europa.eu/resource/dataset/education-credit). Gagnaveitendur geta notað þeirra eigin stýrðan lista.</rdfs:comment>
     <rdfs:comment xml:lang="ga">An creat a úsáidtear chun na pointí creidmheasa a shannadh don tsonraíocht foghlama.
 Ba cheart ainm an chórais creidmheasa a úsáidtear teacht ó stór focal rialaithe (e.g. http://publications.europa.eu/resource/dataset/education-credit). Is féidir le soláthraithe sonraí a liosta nó a liostaí rialaithe féin a úsáid.</rdfs:comment>
@@ -7996,6 +7995,7 @@ The name of the used credit system should come from a controlled vocabulary (e.g
     <rdfs:comment xml:lang="el">Το πλαίσιο που χρησιμοποιήθηκε για την απόδοση των ακαδημαϊκών μονάδων στην προδιαγραφή μάθησης.
 Η ονομασία του χρησιμοποιούμενου συστήματος ακαδημαϊκών μονάδων θα πρέπει να προέρχεται από ελεγχόμενο λεξιλόγιο (π.χ. http://publications.europa.eu/resource/dataset/education-credit). Οι πάροχοι δεδομένων μπορούν να χρησιμοποιούν τον/τους δικό/-ούς τους ελεγχόμενο/-ους κατάλογο/-λόγους.</rdfs:comment>
     <rdfs:label xml:lang="is">rammi</rdfs:label>
+    <rdfs:comment xml:lang="en">The framework used to assign the  credit points to the learning specification. It should be provided using the European Standard List of Educational Credit Systems.</rdfs:comment>
     <rdfs:label xml:lang="lv">ietvars</rdfs:label>
     <rdfs:comment xml:lang="ro">Cadrul utilizat pentru atribuirea de credite specificației de învățare.
 Denumirea sistemului de credite utilizat ar trebui să provină dintr-un vocabular controlat (e.g. http://publications.europa.eu/resource/dataset/education-credit). Furnizorii de date își pot utiliza propriile liste.</rdfs:comment>
@@ -10157,8 +10157,8 @@ Var norādīt tikai vērtības, kas ņemtas no kontrolētas vārdnīcas (piem., 
 Az értéknek (ha meg van adva) ellenőrzött szójegyzékből kell származnia (e.g. http://publications.europa.eu/resource/dataset/supervision-verification). Az adatszolgáltatók használhatják a saját ellenőrzött listájukat (listáikat).</rdfs:comment>
     <rdfs:comment xml:lang="es">Método de supervisión de la evaluación y verificación de la identidad.
 Si se facilita, el valor debe proceder de un vocabulario controlado (por ejemplo, http://publications.europa.eu/resource/dataset/supervision-verification). Los proveedores de datos pueden utilizar su propia lista o listas controladas.</rdfs:comment>
+    <skos:usageNote xml:lang="en">It is recommended to be used with European Standard List of Methods Of Supervision And Verification controlled vocabulary.</skos:usageNote>
     <rdfs:label xml:lang="bg">метод на наблюдение на оценяването и проверка на самоличността</rdfs:label>
-    <skos:usageNote xml:lang="en">It is recommended to be used with Europass Standard List of Methods Of Supervision And Verification controlled vocabulary.</skos:usageNote>
     <rdfs:label xml:lang="es">método de evaluación, supervisión y verificación de la identidad</rdfs:label>
     <rdfs:label xml:lang="tr">değerlendirme denetim ve kimlik doğrulama yöntemi</rdfs:label>
     <rdfs:label xml:lang="cs">metoda hodnocení, dohledu a ověřování totožnosti</rdfs:label>


### PR DESCRIPTION
This PR covers:
- ontology update where all occurence of term **Europass** has been replaced with term **European** 
- ontology documentation update